### PR TITLE
VONK-4620: Added the DataContract annotation to the CanonicalValidator

### DIFF
--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaConverterExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaConverterExtensions.cs
@@ -4,7 +4,6 @@
  * via any medium is strictly prohibited.
  */
 
-using Firely.Fhir.Validation.Impl;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;

--- a/src/Firely.Fhir.Validation/Impl/CanonicalValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/CanonicalValidator.cs
@@ -1,14 +1,16 @@
 ﻿using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Support;
 using Newtonsoft.Json.Linq;
+using System.Runtime.Serialization;
 
-namespace Firely.Fhir.Validation.Impl
+namespace Firely.Fhir.Validation
 {
     /// <summary>
     /// This is an additional validator for the FHIR datatype 'canonical'. As per the FHIR specification, 
     /// canonical URLs are always expected to be absolute URIs or fragment identifiers. 
     /// The purpose of this validator is to enforce this rule and perform the necessary checks.
     /// </summary>
+    [DataContract]
     public class CanonicalValidator : IValidatable
     {
         /// <inheritdoc/>


### PR DESCRIPTION
 Added the `[DataContract]` annotation to the `CanonicalValidator`, otherwise it cannot serialize this item.