### PR TITLE
Add netstandard2.1 as a target

### DIFF
--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -38,9 +38,7 @@
 		<AssemblyOriginatorKeyFile>..\..\FirelyValidatorPubKey.snk</AssemblyOriginatorKeyFile>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<LibraryPKHash>0024000004800000940000000602000000240000525341310004000001000100c11eea5df3095844b027f018b356bc326a5a30b1f245010ad789589aa685569b2eb7f5f2ea5c49dafed338e3d9969eab21848c6c20a6b0a22c5ff7797d9a5062d7f3e42478e905d72a3dde344086a003f2df9deeb838e206d92c8cc59150c3151e9490381321f77a716e0a2b24a585b302ba2b3db37966a3da9abe4c601ba4c1</LibraryPKHash>
-		<WarningsNotAsErrors>NU5104</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -48,5 +46,6 @@
     Consider applying the 'await' operator to the result of the call.	-->
 		<WarningsAsErrors>CS4014</WarningsAsErrors>
 		<WarningsNotAsErrors>NU5104</WarningsNotAsErrors>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 </Project>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -6,7 +6,7 @@
 		<Authors>Firely</Authors>
 		<Company>Firely (https://fire.ly)</Company>
 		<Copyright>Copyright 2015-2022 Firely</Copyright>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
 		<RepositoryUrl>https://github.com/FirelyTeam/firely-validator-api</RepositoryUrl>
 	</PropertyGroup>
 

--- a/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
@@ -4,12 +4,10 @@
  * via any medium is strictly prohibited.
  */
 
-using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -119,7 +117,7 @@ namespace Firely.Fhir.Validation
         public bool ContainsKey(string key) => _childList.ContainsKey(key);
 
         /// <inheritdoc />
-        public bool TryGetValue(string key, [MaybeNullWhen(false)] out IAssertion value) => _childList.TryGetValue(key, out value);
+        public bool TryGetValue(string key, out IAssertion value) => _childList.TryGetValue(key, out value);
 
         /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, IAssertion>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, IAssertion>>)_childList).GetEnumerator();

--- a/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
@@ -8,6 +8,7 @@ using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -116,8 +117,13 @@ namespace Firely.Fhir.Validation
         /// <inheritdoc />
         public bool ContainsKey(string key) => _childList.ContainsKey(key);
 
+#if NET8_0
+        /// <inheritdoc />
+        public bool TryGetValue(string key, [MaybeNullWhen(false)] out IAssertion value) => _childList.TryGetValue(key, out value);
+#else
         /// <inheritdoc />
         public bool TryGetValue(string key, out IAssertion value) => _childList.TryGetValue(key, out value);
+#endif 
 
         /// <inheritdoc />
         public IEnumerator<KeyValuePair<string, IAssertion>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, IAssertion>>)_childList).GetEnumerator();


### PR DESCRIPTION
We will need to support the latest .NET  + netstandard 2.1 for older platforms, but we had forgotten to actually add netstandard as a target framework.