### PR TITLE
Add async validation

### DIFF
--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -2,7 +2,7 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>2.2.1</VersionPrefix>
+		<VersionPrefix>2.3.0</VersionPrefix>
 		<Authors>Firely</Authors>
 		<Company>Firely (https://fire.ly)</Company>
 		<Copyright>Copyright 2015-2024 Firely</Copyright>

--- a/src/Firely.Fhir.Validation.Compilation.STU3/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.Compilation.STU3/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Firely.Fhir.Validation.Compilation.ElementConversionMode.ContentReference = 2 ->
 Firely.Fhir.Validation.Compilation.ElementConversionMode.Full = 0 -> Firely.Fhir.Validation.Compilation.ElementConversionMode
 Firely.Fhir.Validation.Compilation.ISchemaBuilder
 Firely.Fhir.Validation.Compilation.ISchemaBuilder.Build(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode = Firely.Fhir.Validation.Compilation.ElementConversionMode.Full) -> System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IAssertion!>!
+Firely.Fhir.Validation.Compilation.ISchemaBuilder.BuildAsync(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Firely.Fhir.Validation.IAssertion![]!>!
 Firely.Fhir.Validation.Compilation.SchemaBuilder
 Firely.Fhir.Validation.Compilation.SchemaBuilder.Build(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode = Firely.Fhir.Validation.Compilation.ElementConversionMode.Full) -> System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IAssertion!>!
 Firely.Fhir.Validation.Compilation.SchemaBuilder.SchemaBuilder(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! source, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.Compilation.ISchemaBuilder!>? schemaBuilders = null) -> void

--- a/src/Firely.Fhir.Validation.Compilation.Shared/ISchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/ISchemaBuilder.cs
@@ -9,6 +9,9 @@
 using Hl7.Fhir.Specification.Navigation;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation.Compilation
 {
@@ -40,5 +43,24 @@ namespace Firely.Fhir.Validation.Compilation
         IEnumerable<IAssertion> Build(
            ElementDefinitionNavigator nav,
            ElementConversionMode? conversionMode = ElementConversionMode.Full);
+
+        /// <summary>
+        /// Constucts a schema block.
+        /// </summary>
+        /// <param name="nav"></param>
+        /// <param name="conversionMode">The mode indicating the state we are in while constructing the schema block.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+        [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+        [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+        Task<IAssertion[]> BuildAsync(
+           ElementDefinitionNavigator nav,
+           ElementConversionMode? conversionMode,
+           CancellationToken cancellationToken)
+            => Task.FromResult(Build(nav, conversionMode).ToArray());
     }
 }

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilderExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilderExtensions.cs
@@ -8,6 +8,7 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using System.Linq;
+using System.Threading.Tasks;
 
 #pragma warning disable CS0618 // Type or member is obsolete
 
@@ -29,6 +30,21 @@ namespace Firely.Fhir.Validation.Compilation
         /// <returns></returns>
         public static ElementSchema? BuildSchema(this ISchemaBuilder schemaBuilder, ElementDefinitionNavigator nav)
             => schemaBuilder.Build(nav).SingleOrDefault() is ElementSchema schema ? schema : null;
+
+        /// <summary>
+        /// Converts a <see cref="StructureDefinition"/> to an <see cref="ElementSchema"/>.
+        /// </summary>
+        public static Task<ElementSchema?> BuildSchemaAsync(this ISchemaBuilder schemaBuilder, StructureDefinition definition)
+            => BuildSchemaAsync(schemaBuilder, ElementDefinitionNavigator.ForSnapshot(definition));
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="schemaBuilder"></param>
+        /// <param name="nav"></param>
+        /// <returns></returns>
+        public static async Task<ElementSchema?> BuildSchemaAsync(this ISchemaBuilder schemaBuilder, ElementDefinitionNavigator nav)
+            => (await schemaBuilder.BuildAsync(nav, ElementConversionMode.Full, default)).SingleOrDefault() is ElementSchema schema ? schema : null;
     }
 }
 

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/StandardBuilders.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/StandardBuilders.cs
@@ -9,6 +9,8 @@ using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 #pragma warning disable CS0618 // Type or member is obsolete
 
@@ -42,6 +44,16 @@ namespace Firely.Fhir.Validation.Compilation
         /// <inheritdoc/>
         public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
             => _schemaBuilders.SelectMany(ce => ce.Build(nav, conversionMode));
+        async Task<IAssertion[]> ISchemaBuilder.BuildAsync(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode, CancellationToken cancellationToken)
+        {
+            var assertions = new List<IAssertion>();
+            for (int i = 0; i < _schemaBuilders.Length; i++)
+            {
+                assertions.AddRange(await _schemaBuilders[i].BuildAsync(nav, conversionMode, cancellationToken));
+            }
+            
+            return assertions.ToArray();
+        }
     }
 }
 

--- a/src/Firely.Fhir.Validation.Compilation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.Compilation/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Firely.Fhir.Validation.Compilation.ElementConversionMode.ContentReference = 2 ->
 Firely.Fhir.Validation.Compilation.ElementConversionMode.Full = 0 -> Firely.Fhir.Validation.Compilation.ElementConversionMode
 Firely.Fhir.Validation.Compilation.ISchemaBuilder
 Firely.Fhir.Validation.Compilation.ISchemaBuilder.Build(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode = Firely.Fhir.Validation.Compilation.ElementConversionMode.Full) -> System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IAssertion!>!
+Firely.Fhir.Validation.Compilation.ISchemaBuilder.BuildAsync(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Firely.Fhir.Validation.IAssertion![]!>!
 Firely.Fhir.Validation.Compilation.SchemaBuilder
 Firely.Fhir.Validation.Compilation.SchemaBuilder.Build(Hl7.Fhir.Specification.Navigation.ElementDefinitionNavigator! nav, Firely.Fhir.Validation.Compilation.ElementConversionMode? conversionMode = Firely.Fhir.Validation.Compilation.ElementConversionMode.Full) -> System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IAssertion!>!
 Firely.Fhir.Validation.Compilation.SchemaBuilder.SchemaBuilder(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! source, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.Compilation.ISchemaBuilder!>? schemaBuilders = null) -> void

--- a/src/Firely.Fhir.Validation.R4/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.R4/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ Firely.Fhir.Validation.ValidationSettingsExtensions
 Firely.Fhir.Validation.Validator
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.Model.Resource! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.Model.Resource! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
 Firely.Fhir.Validation.Validator.Validator(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! resourceResolver, Hl7.Fhir.Specification.Terminology.ICodeValidationTerminologyService! terminologyService, Firely.Fhir.Validation.IExternalReferenceResolver? referenceResolver = null, Firely.Fhir.Validation.ValidationSettings? settings = null) -> void
 static Firely.Fhir.Validation.ValidationSettingsExtensions.SetSkipConstraintValidation(this Firely.Fhir.Validation.ValidationSettings! vc, bool skip) -> void

--- a/src/Firely.Fhir.Validation.R4B/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.R4B/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ Firely.Fhir.Validation.ValidationSettingsExtensions
 Firely.Fhir.Validation.Validator
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.Model.Resource! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.Model.Resource! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
 Firely.Fhir.Validation.Validator.Validator(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! resourceResolver, Hl7.Fhir.Specification.Terminology.ICodeValidationTerminologyService! terminologyService, Firely.Fhir.Validation.IExternalReferenceResolver? referenceResolver = null, Firely.Fhir.Validation.ValidationSettings? settings = null) -> void
 static Firely.Fhir.Validation.ValidationSettingsExtensions.SetSkipConstraintValidation(this Firely.Fhir.Validation.ValidationSettings! vc, bool skip) -> void

--- a/src/Firely.Fhir.Validation.R5/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.R5/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ Firely.Fhir.Validation.ValidationSettingsExtensions
 Firely.Fhir.Validation.Validator
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.Model.Resource! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.Model.Resource! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
 Firely.Fhir.Validation.Validator.Validator(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! resourceResolver, Hl7.Fhir.Specification.Terminology.ICodeValidationTerminologyService! terminologyService, Firely.Fhir.Validation.IExternalReferenceResolver? referenceResolver = null, Firely.Fhir.Validation.ValidationSettings? settings = null) -> void
 static Firely.Fhir.Validation.ValidationSettingsExtensions.SetSkipConstraintValidation(this Firely.Fhir.Validation.ValidationSettings! vc, bool skip) -> void

--- a/src/Firely.Fhir.Validation.STU3/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation.STU3/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ Firely.Fhir.Validation.ValidationSettingsExtensions
 Firely.Fhir.Validation.Validator
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
 Firely.Fhir.Validation.Validator.Validate(Hl7.Fhir.Model.Resource! instance, string? profile = null) -> Hl7.Fhir.Model.OperationOutcome!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.ElementModel.ElementNode! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
+Firely.Fhir.Validation.Validator.ValidateAsync(Hl7.Fhir.Model.Resource! instance, string? profile, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Hl7.Fhir.Model.OperationOutcome!>!
 Firely.Fhir.Validation.Validator.Validator(Hl7.Fhir.Specification.Source.IAsyncResourceResolver! resourceResolver, Hl7.Fhir.Specification.Terminology.ICodeValidationTerminologyService! terminologyService, Firely.Fhir.Validation.IExternalReferenceResolver? referenceResolver = null, Firely.Fhir.Validation.ValidationSettings? settings = null) -> void
 static Firely.Fhir.Validation.ValidationSettingsExtensions.SetSkipConstraintValidation(this Firely.Fhir.Validation.ValidationSettings! vc, bool skip) -> void

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -111,8 +111,40 @@ namespace Firely.Fhir.Validation
 
         /// <inheritdoc />
         ResultReport IValidatable.Validate(IScopedNode input, ValidationSettings vc, ValidationState s)
-            => TaskHelper.Await(() => ((IValidatable)this).ValidateAsync(input, vc, s, default).AsTask());
+        {
+            if (input is null) throw Error.ArgumentNull(nameof(input));
+            if (input.InstanceType is null) throw Error.Argument(nameof(input), "Binding validation requires input to have an instance type.");
+            if (vc.ValidateCodeService is null)
+                throw new InvalidOperationException($"Encountered a ValidationSettings that does not have" +
+                    $"its non-null {nameof(ValidationSettings.ValidateCodeService)} set.");
 
+            // This would give informational messages even if the validation was run on a choice type with a binding, which is then
+            // only applicable to an instance which is bindable. So instead of a warning, we should just return as validation is
+            // not applicable to this instance.
+            if (!ModelInspector.Base.IsBindable(input.InstanceType))
+            {
+                return vc.TraceResult(() =>
+                    new TraceAssertion(s.Location.InstanceLocation.ToString(),
+                        $"Validation of binding with non-bindable instance type '{input.InstanceType}' always succeeds."));
+            }
+
+            if (input.ParseBindable() is { } bindable)
+            {
+                var result = verifyContentRequirements(input, bindable, s);
+
+                return result.IsSuccessful ?
+                    validateCode(bindable, vc, s)
+                    : result;
+            }
+            else
+            {
+                // When there is no bindable content, the binding is not applicable to the instance, and we will
+                // just return a successful result.
+                return ResultReport.SUCCESS;
+            }
+        }
+
+        /// <inheritdoc />
         async ValueTask<ResultReport> IValidatable.ValidateAsync(IScopedNode input, ValidationSettings vc, ValidationState s, CancellationToken cancellationToken)
         {
             if (input is null) throw Error.ArgumentNull(nameof(input));
@@ -174,6 +206,44 @@ namespace Firely.Fhir.Validation
         private static bool codeableConceptHasCode(CodeableConcept cc) =>
             cc.Coding.Any(cd => !string.IsNullOrEmpty(cd.Code));
 
+
+        private ResultReport validateCode(Element bindable, ValidationSettings vc, ValidationState s)
+        {
+            //EK 20170605 - disabled inclusion of warnings/errors for all but required bindings since this will 
+            // 1) create superfluous messages (both saying the code is not valid) coming from the validateResult + the outcome.AddIssue() 
+            // 2) add the validateResult as warnings for preferred bindings, which are confusing in the case where the slicing entry is 
+            //    validating the binding against the core and slices will refine it: if it does not generate warnings against the slice, 
+            //    it should not generate warnings against the slicing entry.
+            if (Strength != BindingStrength.Required) return ResultReport.SUCCESS;
+
+            var parameters = buildParams()
+                .WithValueSet(ValueSetUri.ToString())
+                .WithAbstract(AbstractAllowed);
+
+            ValidateCodeParameters buildParams()
+            {
+                var vcp = new ValidateCodeParameters();
+
+                return bindable switch
+                {
+                    FhirString str => vcp.WithCode(str.Value, system: null, display: null, context: Context),
+                    FhirUri uri => vcp.WithCode(uri.Value, system: null, display: null, context: Context),
+                    Code co => vcp.WithCode(co.Value, system: null, display: null, context: Context),
+                    Coding cd => vcp.WithCoding(cd),
+                    CodeableConcept cc => vcp.WithCodeableConcept(cc),
+                    _ => throw Error.InvalidOperation($"Parsed bindable was of unexpected instance type '{bindable.TypeName}'.")
+                };
+            }
+
+            var display = buildCodingDisplay(parameters);
+            var result = callService(parameters, vc, display);
+
+            return result switch
+            {
+                (null, _) => ResultReport.SUCCESS,
+                ({ } issue, var message) => new IssueAssertion(issue, message!).AsResult(s)
+            };
+        }
 
         private async Task<ResultReport> validateCodeAsync(Element bindable, ValidationSettings vc, ValidationState s)
         {
@@ -259,6 +329,28 @@ namespace Firely.Fhir.Validation
                 (false, null) => (Issue.TERMINOLOGY_OUTPUT_ERROR, display.Capitalize() + " is invalid, but the terminology service provided no further details."),
                 (false, not null) => (Issue.TERMINOLOGY_OUTPUT_ERROR, message)
             };
+        }
+
+        private static (Issue?, string?) callService(ValidateCodeParameters parameters, ValidationSettings ctx, string display)
+        {
+            try
+            {
+                var callParams = parameters.Build();
+                return interpretResults(TaskHelper.Await(() => ctx.ValidateCodeService.ValueSetValidateCode(callParams)), display);
+            }
+            catch (FhirOperationException tse)
+            {
+                var desiredResult = ctx.HandleValidateCodeServiceFailure?.Invoke(parameters, tse)
+                    ?? TerminologyServiceExceptionResult.Warning;
+
+                var message = $"Terminology service failed while validating {display}: {tse.Message}";
+                return desiredResult switch
+                {
+                    TerminologyServiceExceptionResult.Error => (Issue.TERMINOLOGY_OUTPUT_ERROR, message),
+                    TerminologyServiceExceptionResult.Warning => (Issue.TERMINOLOGY_OUTPUT_WARNING, message),
+                    _ => throw new NotSupportedException("Logic error: unknown terminology service exception result.")
+                };
+            }
         }
 
         private static async Task<(Issue?, string?)> callServiceAsync(ValidateCodeParameters parameters, ValidationSettings ctx, string display)

--- a/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
@@ -152,6 +152,7 @@ namespace Firely.Fhir.Validation
 
             foreach (var m in matchResult.Matches ?? [])
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 evidence.Add(await m.Assertion.ValidateManyAsync(
                         m.InstanceElements ?? NOELEMENTS,
                         vc,

--- a/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ChildrenValidator.cs
@@ -15,6 +15,8 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -118,6 +120,47 @@ namespace Firely.Fhir.Validation
                             .UpdateLocation(vs => vs.ToChild(m.ChildName))
                             .UpdateInstanceLocation(ip => ip.ToChild(m.ChildName, choiceElement(m)))
                     )) ?? Enumerable.Empty<ResultReport>());
+
+            return ResultReport.Combine(evidence);
+
+            static string? choiceElement(Match m) => m.ChildName.EndsWith("[x]") ? m.InstanceElements?.FirstOrDefault()?.InstanceType : null;
+        }
+
+        /// <inheritdoc />
+        async ValueTask<ResultReport> IValidatable.ValidateAsync(IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            if (input.InstanceType is null)
+                throw new ArgumentException($"Cannot validate the resource because {nameof(IScopedNode)} does not have an instance type.");
+
+            var evidence = new List<ResultReport>();
+
+            // Listing children can be an expensive operation, so make sure we run it once.
+            var elementsToMatch = input.Children().ToList();
+
+            // If this is a node with a primitive value, simulate having a child with
+            // this value and the corresponding System type as an ITypedElement
+            if (input.Value is not null && char.IsLower(input.InstanceType[0]) && !elementsToMatch.Any())
+                elementsToMatch.Insert(0, new ValueElementNode(input));
+
+            var matchResult = ChildNameMatcher.Match(ChildList, elementsToMatch);
+            if (matchResult.UnmatchedInstanceElements?.Count > 0 && !AllowAdditionalChildren)
+            {
+                var elementList = string.Join(",", matchResult.UnmatchedInstanceElements.Select(e => $"'{e.Name}'"));
+                evidence.Add(new IssueAssertion(Issue.CONTENT_ELEMENT_HAS_UNKNOWN_CHILDREN, $"Encountered unknown child elements {elementList}")
+                    .AsResult(state));
+            }
+
+            foreach (var m in matchResult.Matches ?? [])
+            {
+                evidence.Add(await m.Assertion.ValidateManyAsync(
+                        m.InstanceElements ?? NOELEMENTS,
+                        vc,
+                        state
+                            .UpdateLocation(vs => vs.ToChild(m.ChildName))
+                            .UpdateInstanceLocation(ip => ip.ToChild(m.ChildName, choiceElement(m))),
+                        cancellationToken
+                    ));
+            }
 
             return ResultReport.Combine(evidence);
 

--- a/src/Firely.Fhir.Validation/Impl/DatatypeSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/DatatypeSchema.cs
@@ -79,6 +79,7 @@ namespace Firely.Fhir.Validation
             var results = new ResultReport[inputs.Count];
             for (int i = 0; i < inputs.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 results[i] = await ValidateInternalAsync(inputs[i], vc, state.UpdateInstanceLocation(d => d.ToIndex(i)), cancellationToken);
             }
 

--- a/src/Firely.Fhir.Validation/Impl/ExtensionSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/ExtensionSchema.cs
@@ -146,6 +146,7 @@ namespace Firely.Fhir.Validation
 
             foreach (var group in groups)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (group.Key is not null)
                 {
 

--- a/src/Firely.Fhir.Validation/Impl/ExtensionSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/ExtensionSchema.cs
@@ -12,6 +12,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -129,6 +131,81 @@ namespace Firely.Fhir.Validation
             static ExtensionUrlFollower callback(ExtensionUrlFollower? follower) =>
                 follower ?? ((l, c) => ExtensionUrlHandling.WarnIfMissing);
         }
+        
+        /// <inheritdoc/>
+        internal override async ValueTask<ResultReport> ValidateInternalAsync(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            // Group the instances by their url - this allows a IGroupValidatable schema for the 
+            // extension to validate the "extension cardinality".
+            var groups = input.GroupBy(instance => GetExtensionUri(instance)).ToArray();
+
+            if (groups.Any() && vc.ElementSchemaResolver is null)
+                throw new ArgumentException($"Cannot validate the extension because {nameof(ValidationSettings)} does not contain an ElementSchemaResolver.");
+
+            var evidence = new List<ResultReport>();
+
+            foreach (var group in groups)
+            {
+                if (group.Key is not null)
+                {
+
+                    var extensionHandling = callback(vc.FollowExtensionUrl).Invoke(state.Location.InstanceLocation.ToString(), group.Key);
+
+                    if (extensionHandling is ExtensionUrlHandling.DontResolve)
+                    {
+                        // Just validate the Extension schema itself.
+                        evidence.Add(await ValidateExtensionSchemaAsync(group, vc, state, cancellationToken));
+                    }
+                    else
+                    {
+                        // Resolve the uri to a schema only when instructed
+                        var validator = vc.ElementSchemaResolver!.GetSchema(group.Key);
+
+                        if (validator is null)
+                        {
+                            var isModifierExtension = group.First().Name == "modifierExtension";
+
+                            var (vr, issue) = extensionHandling switch
+                            {
+                                _ when isModifierExtension => (ValidationResult.Failure, Issue.UNAVAILABLE_REFERENCED_PROFILE),
+                                ExtensionUrlHandling.WarnIfMissing => (ValidationResult.Success, Issue.UNAVAILABLE_REFERENCED_PROFILE_WARNING),
+                                ExtensionUrlHandling.ErrorIfMissing => (ValidationResult.Failure, Issue.UNAVAILABLE_REFERENCED_PROFILE),
+                                _ => (ValidationResult.Undecided, Issue.UNAVAILABLE_REFERENCED_PROFILE) // this case will never happen
+                            };
+
+                            evidence.Add(new ResultReport(vr,
+                                new IssueAssertion(issue, $"Unable to resolve reference to extension '{group.Key}'.")
+                                    .AsResult(state).Evidence));
+
+                            // No url available - validate the Extension schema itself.
+                            evidence.Add(await ValidateExtensionSchemaAsync(group, vc, state, cancellationToken));
+                        }
+                        else
+                        {
+                            var schema = validator switch
+                            {
+                                ExtensionSchema es => es,
+                                var other => throw new InvalidOperationException($"The schema returned for an extension should be of type {nameof(ExtensionSchema)}, not {other.GetType()}.")
+                            };
+
+                            // Now that we have fetched the extension, call its constraint validation - this should exclude the
+                            // special fetch magic for the url (this function) to avoid a loop, so we call the actual validation here.
+                            evidence.Add(await schema.ValidateExtensionSchemaAsync(group, vc, state, cancellationToken));
+                        }
+                    }
+                }
+                else
+                {
+                    // No url available - validate the Extension schema itself.
+                    evidence.Add(await ValidateExtensionSchemaAsync(group, vc, state, cancellationToken));
+                }
+            }
+
+            return ResultReport.Combine(evidence);
+
+            static ExtensionUrlFollower callback(ExtensionUrlFollower? follower) =>
+                follower ?? ((l, c) => ExtensionUrlHandling.WarnIfMissing);
+        }
 
         /// <summary>
         /// This invokes the actual validation for an Extension schema, without the special magic of 
@@ -137,6 +214,15 @@ namespace Firely.Fhir.Validation
         ResultReport ValidateExtensionSchema(IEnumerable<IScopedNode> input,
             ValidationSettings vc,
             ValidationState state) => base.ValidateInternal(input, vc, state);
+
+        /// <summary>
+        /// This invokes the actual validation for an Extension schema, without the special magic of 
+        /// fetching the url, so this is the "normal" schema validation.
+        /// </summary>
+        ValueTask<ResultReport> ValidateExtensionSchemaAsync(IEnumerable<IScopedNode> input,
+            ValidationSettings vc,
+            ValidationState state,
+            CancellationToken cancellationToken) => base.ValidateInternalAsync(input, vc, state, cancellationToken);
 
         /// <inheritdoc/>
         internal override ResultReport ValidateInternal(IScopedNode input, ValidationSettings vc, ValidationState state) =>

--- a/src/Firely.Fhir.Validation/Impl/FhirSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirSchema.cs
@@ -12,6 +12,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -66,6 +68,23 @@ namespace Firely.Fhir.Validation
         {
             state = state.UpdateLocation(sp => sp.InvokeSchema(this));
             return base.ValidateInternal(input, vc, state);
+        }
+
+        internal override ValueTask<ResultReport> ValidateInternalAsync(IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            if (input.InstanceType is null)
+                throw new ArgumentException($"Cannot validate the resource because {nameof(IScopedNode)} does not have an instance type.");
+
+            state = state
+                .UpdateLocation(sp => sp.InvokeSchema(this))
+                .UpdateInstanceLocation(ip => ip.StartResource(input.InstanceType));
+            return base.ValidateInternalAsync(input, vc, state, cancellationToken);
+        }
+
+        internal override ValueTask<ResultReport> ValidateInternalAsync(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            state = state.UpdateLocation(sp => sp.InvokeSchema(this));
+            return base.ValidateInternalAsync(input, vc, state, cancellationToken);
         }
 
         /// <summary>

--- a/src/Firely.Fhir.Validation/Impl/ResourceSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/ResourceSchema.cs
@@ -129,6 +129,7 @@ namespace Firely.Fhir.Validation
             ResultReport[] results = new ResultReport[inputs.Count];
             for (int i = 0; i < inputs.Count; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 results[i] = await ValidateInternalAsync(inputs[i], vc, state.UpdateInstanceLocation(d => d.ToIndex(i)), cancellationToken);
             }
 
@@ -182,11 +183,13 @@ namespace Firely.Fhir.Validation
             };
             foreach (var s in minimalSet)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 validationResult.Add(await s.ValidateResourceSchemaAsync(input, vc, state, cancellationToken));
             }
 
             foreach (var s in fetchedNonFhirSchemas)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 validationResult.Add(await s.ValidateInternalAsync(input, vc, state, cancellationToken));
             }
 

--- a/src/Firely.Fhir.Validation/Impl/SliceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/SliceValidator.cs
@@ -224,6 +224,7 @@ namespace Firely.Fhir.Validation
             // Go over the elements in the instance, in order
             foreach (var candidate in input)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 candidateNumber += 1;
                 bool hasSucceeded = false;
 
@@ -333,6 +334,7 @@ namespace Firely.Fhir.Validation
                 int i = 0;
                 foreach (var slice in this)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     result[i++] = await slice.Key.Assertion.ValidateManyAsync(toListOfTypedElements(slice.Value), vc, forSlice(state, slice.Key.Name, slice.Value), cancellationToken);
                 }
 

--- a/src/Firely.Fhir.Validation/Impl/SliceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/SliceValidator.cs
@@ -13,6 +13,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -203,6 +205,82 @@ namespace Firely.Fhir.Validation
             return ResultReport.Combine(evidence);
         }
 
+        /// <inheritdoc/>
+        ValueTask<ResultReport> IValidatable.ValidateAsync(IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            => ((IGroupValidatable)this).ValidateAsync([input], vc, state, cancellationToken);
+
+
+        /// <inheritdoc cref="IGroupValidatable.ValidateAsync(IEnumerable{IScopedNode}, ValidationSettings, ValidationState, CancellationToken)"/>
+        async ValueTask<ResultReport> IGroupValidatable.ValidateAsync(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            var lastMatchingSlice = -1;
+            var defaultInUse = false;
+            List<ResultReport> evidence = new();
+            var buckets = new Buckets(Slices, Default);
+
+            var candidateNumber = -1;  // instead of location - replace this with location later.
+            var sliceLocation = state.Location.InstanceLocation.ToString();
+
+            // Go over the elements in the instance, in order
+            foreach (var candidate in input)
+            {
+                candidateNumber += 1;
+                bool hasSucceeded = false;
+
+                // Try to find the child slice that this element matches
+                for (var sliceNumber = 0; sliceNumber < Slices.Count; sliceNumber++)
+                {
+                    var sliceName = Slices[sliceNumber].Name;
+                    var conditionResult = await Slices[sliceNumber].Condition.ValidateOneAsync(candidate, vc, state, cancellationToken);
+
+                    if (conditionResult.IsSuccessful)
+                    {
+                        // traces.Add(new TraceAssertion(groupLocation, $"Input[{candidateNumber}] matched slice {sliceName}."));
+
+                        // The instance matched a slice that we have already passed, if order matters, 
+                        // this is not allowed
+                        if (sliceNumber < lastMatchingSlice && Ordered)
+                            evidence.Add(new IssueAssertion(Issue.CONTENT_ELEMENT_SLICING_OUT_OF_ORDER, $"Element matches slice {sliceLocation}:{sliceName}', but this is out of order for group {sliceLocation}, since a previous element already matched slice '{sliceLocation}:{Slices[lastMatchingSlice].Name}'")
+                                .AsResult(state));
+                        else
+                            lastMatchingSlice = sliceNumber;
+
+                        if (defaultInUse && DefaultAtEnd)
+                        {
+                            // We found a match while we already added a non-match to a "open at end" slicegroup, that's not allowed
+                            evidence.Add(new IssueAssertion(Issue.CONTENT_ELEMENT_FAILS_SLICING_RULE, $"Element matched slice '{sliceLocation}:{sliceName}', but it appears after a non-match, which is not allowed for an open-at-end group")
+                                .AsResult(state));
+                        }
+
+                        hasSucceeded = true;
+                        //result += conditionResult; - for discriminatorless slicing, this would actually be "the" result, but
+                        //we don't know we're using discriminatorless slicing here anymore.  For all other slicing, it is not
+                        //necessary to know why we failed each individual case (except maybe for debugging purposes, but this would
+                        //produce an enormous amount of information
+
+                        // to add to slice
+                        buckets.AddToSlice(Slices[sliceNumber], candidate, candidateNumber);
+
+                        // If we allow only one match, stop trying to match other cases.
+                        if (!MultiCase) break;
+                    }
+                }
+
+                // So we found no slice that can take this candidate, let's pass it to the default slice
+                if (!hasSucceeded)
+                {
+                    // traces.Add(new TraceAssertion(groupLocation, $"Input[{candidateNumber}] did not match any slice."));
+
+                    defaultInUse = true;
+                    buckets.AddToDefault(candidate, candidateNumber);
+                }
+            }
+
+            evidence.AddRange(await buckets.ValidateAsync(vc, state, cancellationToken));
+
+            return ResultReport.Combine(evidence);
+        }
+
         /// <inheritdoc cref="IJsonSerializable.ToJson"/>
         public JToken ToJson()
         {
@@ -248,6 +326,20 @@ namespace Firely.Fhir.Validation
             public ResultReport[] Validate(ValidationSettings vc, ValidationState state)
                 => this.Select(slice => slice.Key.Assertion.ValidateMany(toListOfTypedElements(slice.Value), vc, forSlice(state, slice.Key.Name, slice.Value)))
                         .Append(_defaultAssertion.ValidateMany(_defaultBucket.Select(d => d.Node), vc, forSlice(state, "@default", _defaultBucket))).ToArray();
+
+            public async Task<ResultReport[]> ValidateAsync(ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            {
+                var result = new ResultReport[this.Count + 1];
+                int i = 0;
+                foreach (var slice in this)
+                {
+                    result[i++] = await slice.Key.Assertion.ValidateManyAsync(toListOfTypedElements(slice.Value), vc, forSlice(state, slice.Key.Name, slice.Value), cancellationToken);
+                }
+
+                result[i++] = await _defaultAssertion.ValidateManyAsync(_defaultBucket.Select(d => d.Node), vc, forSlice(state, "@default", _defaultBucket), cancellationToken);
+
+                return result;
+            }
 
             private static ValidationState forSlice(ValidationState current, string sliceName, IList<OrderedTypedElement>? list) =>
                 current

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -136,10 +136,12 @@ Firely.Fhir.Validation.FixedValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.IAssertion
 Firely.Fhir.Validation.IElementSchemaResolver
 Firely.Fhir.Validation.IElementSchemaResolver.GetSchema(Firely.Fhir.Validation.Canonical! schemaUri) -> Firely.Fhir.Validation.ElementSchema?
+Firely.Fhir.Validation.IElementSchemaResolver.GetSchemaAsync(Firely.Fhir.Validation.Canonical! schemaUri) -> System.Threading.Tasks.ValueTask<Firely.Fhir.Validation.ElementSchema?>
 Firely.Fhir.Validation.IExternalReferenceResolver
 Firely.Fhir.Validation.IExternalReferenceResolver.ResolveAsync(string! reference) -> System.Threading.Tasks.Task<object?>!
 Firely.Fhir.Validation.IGroupValidatable
 Firely.Fhir.Validation.IGroupValidatable.Validate(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IScopedNode!>! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state) -> Firely.Fhir.Validation.ResultReport!
+Firely.Fhir.Validation.IGroupValidatable.ValidateAsync(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IScopedNode!>! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Firely.Fhir.Validation.ResultReport!>
 Firely.Fhir.Validation.IJsonSerializable
 Firely.Fhir.Validation.IJsonSerializable.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.InMemoryExternalReferenceResolver
@@ -165,6 +167,7 @@ Firely.Fhir.Validation.IssueAssertion.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.IssueAssertion.Type.get -> Hl7.Fhir.Model.OperationOutcome.IssueType?
 Firely.Fhir.Validation.IValidatable
 Firely.Fhir.Validation.IValidatable.Validate(Firely.Fhir.Validation.IScopedNode! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state) -> Firely.Fhir.Validation.ResultReport!
+Firely.Fhir.Validation.IValidatable.ValidateAsync(Firely.Fhir.Validation.IScopedNode! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<Firely.Fhir.Validation.ResultReport!>
 Firely.Fhir.Validation.MaxLengthValidator
 Firely.Fhir.Validation.MaxLengthValidator.MaximumLength.get -> int
 Firely.Fhir.Validation.MaxLengthValidator.MaxLengthValidator(int maximumLength) -> void

--- a/src/Firely.Fhir.Validation/Schema/AssertionValidators.cs
+++ b/src/Firely.Fhir.Validation/Schema/AssertionValidators.cs
@@ -133,6 +133,8 @@ namespace Firely.Fhir.Validation
                 var reports = new ResultReport[inputs.Count];
                 for (var i = 0; i < inputs.Count; i++)
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var item = inputs[i];
                     reports[i] = await assertion.ValidateAsync(item, vc, state.UpdateInstanceLocation(vs => vs.ToIndex(i)), cancellationToken);
                 }

--- a/src/Firely.Fhir.Validation/Schema/AssertionValidators.cs
+++ b/src/Firely.Fhir.Validation/Schema/AssertionValidators.cs
@@ -10,6 +10,8 @@ using Hl7.Fhir.ElementModel;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -51,6 +53,18 @@ namespace Firely.Fhir.Validation
         /// <summary>
         /// Validates a single instance element against an assertion.
         /// </summary>
+        internal static ValueTask<ResultReport> ValidateAsync(this IAssertion assertion, IScopedNode input, ValidationSettings vc, CancellationToken cancellationToken)
+            => assertion.ValidateOneAsync(input, vc, new ValidationState(), cancellationToken);
+
+        /// <summary>
+        /// Validates a single instance element against an assertion.
+        /// </summary>
+        internal static ValueTask<ResultReport> ValidateAsync(this IAssertion assertion, ITypedElement input, ValidationSettings vc, CancellationToken cancellationToken)
+            => assertion.ValidateOneAsync(input.AsScopedNode(), vc, new ValidationState(), cancellationToken);
+
+        /// <summary>
+        /// Validates a single instance element against an assertion.
+        /// </summary>
         public static ResultReport Validate(this IAssertion assertion, ITypedElement input, ValidationSettings vc)
             => assertion.ValidateOne(input.AsScopedNode(), vc, new ValidationState());
 
@@ -85,6 +99,49 @@ namespace Firely.Fhir.Validation
         }
 
         /// <summary>
+        /// Validates a group of instance elements using an assertion.
+        /// </summary>
+        /// <remarks>If the assertion is an <see cref="IGroupValidatable"/>, this will simply invoke the
+        /// corresponding method on the validator. If not, it will call the validation on the assertion for
+        /// each of the instances in the group and combine the result.</remarks>
+        internal static ValueTask<ResultReport> ValidateManyAsync(this IAssertion assertion, IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+        {
+            return assertion switch
+            {
+                IGroupValidatable groupvalidatable => groupvalidatable.ValidateAsync(input, vc, state, cancellationToken),
+                IValidatable validatable => repeat(validatable, input, vc, state, cancellationToken),
+                _ => new(ResultReport.SUCCESS),
+            };
+
+            // Turn the validation of a group of elements using a <see cref="IGroupValidatable"/> into
+            // a sequence of calls of each element in the group against a <see cref="IValidatable"/>, and
+            // then combines the results of each of these calls.
+            static ValueTask<ResultReport> repeat(IValidatable assertion, IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            {
+                return input.ToList() switch
+                {
+                    { Count: 0 } => new(ResultReport.SUCCESS),
+                    { Count: 1 } when input.Single() is ValueElementNode ve => assertion.ValidateAsync(ve, vc, state, cancellationToken), // no index for ValueElementNode
+                    { Count: 1 } => assertion.ValidateAsync(input.Single(), vc, state.UpdateInstanceLocation(vs => vs.ToIndex(0)), cancellationToken),
+                    _ => combined(assertion, input, vc, state, cancellationToken)
+                };
+            }
+
+            async static ValueTask<ResultReport> combined(IValidatable assertion, IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            {
+                var inputs = input.ToList();
+                var reports = new ResultReport[inputs.Count];
+                for (var i = 0; i < inputs.Count; i++)
+                {
+                    var item = inputs[i];
+                    reports[i] = await assertion.ValidateAsync(item, vc, state.UpdateInstanceLocation(vs => vs.ToIndex(i)), cancellationToken);
+                }
+
+                return ResultReport.Combine(reports);
+            }
+        }
+
+        /// <summary>
         /// Validates a single instance element using an assertion.
         /// </summary>
         /// <remarks>If the assertion is an <see cref="IValidatable"/>, this will simply invoke the
@@ -95,6 +152,19 @@ namespace Firely.Fhir.Validation
             {
                 IValidatable validatable => validatable.Validate(input, vc, state),
                 _ => ResultReport.SUCCESS
+            };
+
+        /// <summary>
+        /// Validates a single instance element using an assertion.
+        /// </summary>
+        /// <remarks>If the assertion is an <see cref="IValidatable"/>, this will simply invoke the
+        /// corresponding method on the validator. If not, it will wrap the single instance as a group
+        /// and call validation for the <see cref="IGroupValidatable"/>.</remarks>
+        internal static ValueTask<ResultReport> ValidateOneAsync(this IAssertion assertion, IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken) =>
+            assertion switch
+            {
+                IValidatable validatable => validatable.ValidateAsync(input, vc, state, cancellationToken),
+                _ => new(ResultReport.SUCCESS)
             };
 
         /// <summary>

--- a/src/Firely.Fhir.Validation/Schema/IElementSchemaResolver.cs
+++ b/src/Firely.Fhir.Validation/Schema/IElementSchemaResolver.cs
@@ -6,6 +6,8 @@
  * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
  */
 
+using System.Threading.Tasks;
+
 namespace Firely.Fhir.Validation
 {
     /// <summary>
@@ -20,5 +22,14 @@ namespace Firely.Fhir.Validation
         /// <returns>Returns null if the schema was not found.</returns>
         /// <exception cref="SchemaResolutionFailedException">Thrown when the schema was found, but could not be loaded or parsed.</exception>
         ElementSchema? GetSchema(Canonical schemaUri);
+
+        /// <summary>
+        /// Retrieve a schema by its schema uri.
+        /// </summary>
+        /// <param name="schemaUri"></param>
+        /// <returns>Returns null if the schema was not found.</returns>
+        /// <exception cref="SchemaResolutionFailedException">Thrown when the schema was found, but could not be loaded or parsed.</exception>
+        ValueTask<ElementSchema?> GetSchemaAsync(Canonical schemaUri)
+            => new(GetSchema(schemaUri));
     }
 }

--- a/src/Firely.Fhir.Validation/Schema/IGroupValidatable.cs
+++ b/src/Firely.Fhir.Validation/Schema/IGroupValidatable.cs
@@ -8,6 +8,8 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Firely.Fhir.Validation
 {
@@ -27,5 +29,11 @@ namespace Firely.Fhir.Validation
         /// Validates a set of instances, given a location representative for the group.
         /// </summary>
         ResultReport Validate(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state);
+
+        /// <summary>
+        /// Validates a set of instances, given a location representative for the group.
+        /// </summary>
+        ValueTask<ResultReport> ValidateAsync(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            => new(Validate(input, vc, state));
     }
 }

--- a/src/Firely.Fhir.Validation/Schema/IValidatable.cs
+++ b/src/Firely.Fhir.Validation/Schema/IValidatable.cs
@@ -7,6 +7,8 @@
  */
 
 using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -25,5 +27,11 @@ namespace Firely.Fhir.Validation
         /// Validates a single instance.
         /// </summary>
         ResultReport Validate(IScopedNode input, ValidationSettings vc, ValidationState state);
+
+        /// <summary>
+        /// Validates a single instance.
+        /// </summary>
+        ValueTask<ResultReport> ValidateAsync(IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
+            => new(Validate(input, vc, state));
     }
 }

--- a/src/Firely.Fhir.Validation/Schema/ValidationSettings.cs
+++ b/src/Firely.Fhir.Validation/Schema/ValidationSettings.cs
@@ -231,7 +231,7 @@ namespace Firely.Fhir.Validation
     /// <summary>
     /// A delegate that resolves a reference to another resource, outside of the current instance under validation.
     /// </summary>
-    internal delegate ITypedElement? ExternalReferenceResolver(string reference, string location);
+    internal delegate Task<ITypedElement?> ExternalReferenceResolver(string reference, string location);
 
     /// <summary>
     /// A function that determines which profiles in <see cref="Meta.Profile"/> the validator should use to validate this instance.

--- a/src/Firely.Fhir.Validation/Support/MultiElementSchemaResolver.cs
+++ b/src/Firely.Fhir.Validation/Support/MultiElementSchemaResolver.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation
 {
@@ -58,6 +59,17 @@ namespace Firely.Fhir.Validation
 
             foreach (var resolver in Sources)
                 if (resolver.GetSchema(schemaUri) is { } result) return result;
+
+            return null;
+        }
+
+        async ValueTask<ElementSchema?> IElementSchemaResolver.GetSchemaAsync(Canonical schemaUri)
+        {
+            // This won't work unless we use async enumerables - which are not yet available for all platfors.
+            // return Sources.Select(s => s.GetSchema(schemaUri)).FirstOrDefault(res => res is not null);
+
+            foreach (var resolver in Sources)
+                if (await resolver.GetSchemaAsync(schemaUri) is { } result) return result;
 
             return null;
         }

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Import Project="..\..\firely-validator-api.props" />
-
 	<PropertyGroup>
+	    <TargetFramework>net8.0</TargetFramework>
+	    <LangVersion>12.0</LangVersion>
+	    <FirelySdkVersion>5.8.1</FirelySdkVersion>
 		<OutputType>Exe</OutputType>
 		<AssemblyName>Benchmarks</AssemblyName>
 		<RootNamespace>Firely.Fhir.Validation.Benchmarks</RootNamespace>
@@ -71,17 +72,13 @@
 	<ItemGroup>
 		<PackageReference Include="Hl7.Fhir.Base" Version="$(FirelySdkVersion)" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+	    <PackageReference Include="Hl7.Fhir.Validation.Legacy.R4" Version="$(FirelySdkVersion)" />
+	    <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="$(FirelySdkVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\Firely.Fhir.Validation.R4\Firely.Fhir.Validation.R4.csproj" />
 	</ItemGroup>
-
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-		<SignAssembly>True</SignAssembly>
-		<DelaySign>true</DelaySign>
-		<AssemblyOriginatorKeyFile>..\..\FirelyValidatorPubKey.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
 
 </Project>
 

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -4,7 +4,12 @@ namespace Firely.Sdk.Benchmarks
 {
     public class Program
     {
-        private static void Main(string[] args) => BenchmarkRunner.Run<ValidatorBenchmarks>();
+        private static void Main(string[] args)
+#if DEBUG
+            => BenchmarkRunner.Run<ValidatorBenchmarks>(new BenchmarkDotNet.Configs.DebugInProcessConfig());
+#else
+            => BenchmarkRunner.Run<ValidatorBenchmarks>();
+#endif
         //   BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/FhirTests/ITestValidator.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/FhirTests/ITestValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Source;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation.Compilation.Tests
 {
@@ -27,6 +28,8 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         bool CannotValidateTest(TestCase c);
 
         OperationOutcome Validate(ITypedElement instance, IResourceResolver? resolver, string? profile = null);
+
+        Task<OperationOutcome> ValidateAsync(ITypedElement instance, IResourceResolver? resolver, string? profile = null);
 
         OperationOutcome? GetExpectedOperationOutcome(IValidatorEnginesResults engine);
 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/FhirTests/ValidationManifestTest.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/FhirTests/ValidationManifestTest.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation.Compilation.Tests
 {
@@ -47,6 +48,18 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         [ValidationManifestDataSource(TEST_CASES_MANIFEST)]
         public void RunFirelySdkTests(TestCase testCase, string baseDirectory)
                 => _runner.RunTestCase(testCase, DotNetValidator.Create(), baseDirectory, AssertionOptions.OutputTextAssertion);
+
+        /// <summary>
+        /// Running the testcases from the repo https://github.com/FHIR/fhir-test-cases, using the Firely SDK expectation.
+        /// This is the base line for the Validator engine in this solution. Any failures of this tests will come from a change in the validator.
+        /// </summary>
+        /// <param name="testCase">the single testcase to run</param>
+        /// <param name="baseDirectory">the base directory of the testcase</param>
+        [DataTestMethod]
+        [TestCategory("LongRunner")]
+        [ValidationManifestDataSource(TEST_CASES_MANIFEST)]
+        public Task RunFirelySdkTestsAsync(TestCase testCase, string baseDirectory)
+                => _runner.RunTestCaseAsync(testCase, DotNetValidator.Create(), baseDirectory, AssertionOptions.OutputTextAssertion);
 
 
         /// <summary>

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ResourceSchemaValidationTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ResourceSchemaValidationTests.cs
@@ -13,8 +13,10 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
-
+using Task = System.Threading.Tasks.Task;
+ 
 namespace Firely.Fhir.Validation.Tests
 {
     [Trait("Category", "Validation")]
@@ -24,7 +26,7 @@ namespace Firely.Fhir.Validation.Tests
 
         public ResourceSchemaValidationTests(SchemaBuilderFixture fixture) => _fixture = fixture;
 
-        private ITypedElement? resolveTestData(string uri, string location)
+        private async Task<ITypedElement?> resolveTestData(string uri, string location)
         {
             string Url = "http://test.org/fhir/Organization/3141";
             Organization dummy = new() { Id = "3141", Name = "Dummy" };
@@ -38,6 +40,16 @@ namespace Firely.Fhir.Validation.Tests
             var p = new Patient() { Deceased = new FhirString("wrong") };
             var schema = _fixture.SchemaResolver.GetSchema(Canonical.ForCoreType("Resource"))!;
             var result = schema.Validate(p.ToTypedElement(), _fixture.NewValidationSettings());
+            result.IsSuccessful.Should().BeFalse();
+            result.Evidence.Should().ContainSingle(ass => ass is IssueAssertion && ((IssueAssertion)ass).IssueNumber == Issue.CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE.Code);
+        }
+
+        [Fact]
+        public async Task DoesValidateBasedOnActualTypeAsync()
+        {
+            var p = new Patient() { Deceased = new FhirString("wrong") };
+            var schema = _fixture.SchemaResolver.GetSchema(Canonical.ForCoreType("Resource"))!;
+            var result = await schema.ValidateAsync(p.ToTypedElement(), _fixture.NewValidationSettings(), default);
             result.IsSuccessful.Should().BeFalse();
             result.Evidence.Should().ContainSingle(ass => ass is IssueAssertion && ((IssueAssertion)ass).IssueNumber == Issue.CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE.Code);
         }
@@ -90,6 +102,65 @@ namespace Firely.Fhir.Validation.Tests
 
             var validationState = new ValidationState();
             var result = schemaElement!.ValidateInternal(new ScopedNode(all.ToTypedElement()).AsScopedNode(), vc, validationState);
+            result.Result.Should().Be(ValidationResult.Failure);
+            var issues = result.Evidence.OfType<IssueAssertion>().ToList();
+            issues.Count.Should().Be(1);  // Bundle.entry[2].resource[0] is validated twice against different profiles.
+            issues.ForEach(i => i.Message.Should().Contain("does not match regex"));
+
+            validationState.Global.ResourcesValidated.Should().Be(9);
+            validationState.Global.RunValidations.Count.Should().Be(9);
+
+            static string refr(string x) => "http://test.org/fhir/" + x;
+        }
+
+        [Fact]
+        public async Task AvoidsRedoingProfileValidationAsync()
+        {
+            var all = new Bundle() { Type = Bundle.BundleType.Collection };
+            var org1 = new Organization() { Id = "org1", Name = "Organization 1" };
+            var org2 = new Organization() { Id = "org2", Name = "Organization 2", Meta = new() { Profile = new[] { TestProfileArtifactSource.PROFILEDORG2 } } };
+
+            all.Entry.Add(new() { FullUrl = refr("org1"), Resource = org1 });
+            all.Entry.Add(new() { FullUrl = refr("org2"), Resource = org2 });
+
+            var bothRef = new List<ResourceReference>()
+            {
+                new ResourceReference("#refme"),
+                new ResourceReference(refr("org1")),
+                new ResourceReference(refr("org2")),
+                new ResourceReference("http://test.org/fhir/Organization/3141")
+            };
+
+            var pat1 = new Patient()
+            {
+                Meta = new() { Profile = new[] { TestProfileArtifactSource.PATIENTWITHPROFILEDREFS } },
+                Id = "pat1",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org1")),
+                BirthDate = new("2011crap")
+            };
+
+            pat1.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            var pat2 = new Patient()
+            {
+                Meta = new() { Profile = new[] { TestProfileArtifactSource.PATIENTWITHPROFILEDREFS } },
+                Id = "pat2",
+                GeneralPractitioner = bothRef,
+                ManagingOrganization = new(refr("org2"))
+            };
+
+            pat2.Contained.Add(new Organization { Id = "refme", Name = "referred" });
+
+            all.Entry.Add(new() { FullUrl = refr("pat1"), Resource = pat1 });
+            all.Entry.Add(new() { FullUrl = refr("pat2"), Resource = pat2 });
+
+            var schemaElement = _fixture.SchemaResolver.GetSchema("http://hl7.org/fhir/StructureDefinition/Bundle");
+            var vc = _fixture.NewValidationSettings();
+            vc.ResolveExternalReference = resolveTestData;
+
+            var validationState = new ValidationState();
+            var result = await schemaElement!.ValidateInternalAsync(new ScopedNode(all.ToTypedElement()).AsScopedNode(), vc, validationState, default);
             result.Result.Should().Be(ValidationResult.Failure);
             var issues = result.Evidence.OfType<IssueAssertion>().ToList();
             issues.Count.Should().Be(1);  // Bundle.entry[2].resource[0] is validated twice against different profiles.

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/TypeReferenceBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/TypeReferenceBuilderTests.cs
@@ -10,7 +10,9 @@ using FluentAssertions.Primitives;
 using Hl7.Fhir.Model;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Firely.Fhir.Validation.Compilation.Tests
 {
@@ -43,11 +45,11 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         private const string IDENTIFIER_PROFILE = HL7SDPREFIX + "Identifier";
 
         [Fact]
-        public void TypRefWithMultipleProfilesShouldResultInASliceWithSchemaAssertions()
+        public async Task TypRefWithMultipleProfilesShouldResultInASliceWithSchemaAssertions()
         {
             // This doesnt make sense, but by having two profiles on the same type, we're not generating a typelabel slicer first, 
             // but immediately go through slicing based on profile
-            var sch = convert("Identifier", profiles: new[] { TestProfileArtifactSource.PROFILEDORG1, TestProfileArtifactSource.PROFILEDORG2 });
+            var sch = await convert("Identifier", profiles: new[] { TestProfileArtifactSource.PROFILEDORG1, TestProfileArtifactSource.PROFILEDORG2 });
 
             var sa = sch.Should().BeOfType<AnyValidator>().Subject;
             sa.Members.Should().HaveCount(2);
@@ -58,16 +60,16 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void TypRefShouldHaveADefaultProfile()
+        public async Task TypRefShouldHaveADefaultProfile()
         {
-            var sch = convert("Identifier");
+            var sch = await convert("Identifier");
             sch.Should().BeASchemaAssertionFor(IDENTIFIER_PROFILE);
         }
 
         [Fact]
-        public void MultipleTypRefsShouldResultInATypeSlice()
+        public async Task MultipleTypRefsShouldResultInATypeSlice()
         {
-            var sch = convert(new[] { build("Identifier"), build("Code") });
+            var sch = await convert(new[] { build("Identifier"), build("Code") });
 
             var sa = sch.Should().BeOfType<SliceValidator>().Subject;
             sa.Slices.Should().HaveCount(2);
@@ -81,9 +83,9 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void NakedReferenceTypeShouldHaveReferenceValidationAgainstDefaults()
+        public async Task NakedReferenceTypeShouldHaveReferenceValidationAgainstDefaults()
         {
-            var sch = convert("Reference");
+            var sch = await convert("Reference");
             var all = sch.Should().BeOfType<AllValidator>().Subject;
 
             all.Members.Should().HaveCount(2);
@@ -94,23 +96,23 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void SupportsR3StylePrimitiveTypeRefs()
+        public async Task SupportsR3StylePrimitiveTypeRefs()
         {
             ElementDefinition.TypeRefComponent rc = new();
             var ce = new FhirUri();
             ce.SetStringExtension(CommonTypeRefComponentExtensions.SDXMLTYPEEXTENSION, "xsd:token");
             rc.CodeElement = ce;
 
-            var converted = convertTypeReference(rc);
+            var converted = await convertTypeReference(rc);
             converted.Should().BeOfType<SchemaReferenceValidator>().Which.SchemaUri.
                 Should().Be(new Canonical("http://hl7.org/fhirpath/System.String"));
         }
 
 
         [Fact]
-        public void ReferenceWithTargetProfilesShouldHaveReferenceValidationAgainstProfiles()
+        public async Task ReferenceWithTargetProfilesShouldHaveReferenceValidationAgainstProfiles()
         {
-            var sch = convert("Reference", targets: new[] { TestProfileArtifactSource.PROFILEDPROCEDURE });
+            var sch = await convert("Reference", targets: new[] { TestProfileArtifactSource.PROFILEDPROCEDURE });
             var all = sch.Should().BeOfType<AllValidator>().Subject;
 
             all.Members.Should().HaveCount(2);
@@ -121,13 +123,13 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void AggregationConstraintsForReferenceShouldBeGenerated()
+        public async Task AggregationConstraintsForReferenceShouldBeGenerated()
         {
             var tr = build("Reference", targets: new[] { TestProfileArtifactSource.PROFILEDPROCEDURE });
             tr.AggregationElement.Add(new Code<ElementDefinition.AggregationMode>(ElementDefinition.AggregationMode.Bundled));
             tr.Versioning = ElementDefinition.ReferenceVersionRules.Independent;
 
-            var sch = convertTypeReference(tr);
+            var sch = await convertTypeReference(tr);
             var rr = sch.Should().BeOfType<AllValidator>().Subject
                 .Members[1].Should().BeOfType<ReferencedInstanceValidator>().Subject;
 
@@ -136,32 +138,32 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void ExtensionTypeShouldUseDynamicSchemaReferenceValidator()
+        public async Task ExtensionTypeShouldUseDynamicSchemaReferenceValidator()
         {
-            var sch = convert("Extension", profiles: new[] { TestProfileArtifactSource.PROFILEDORG1 });
+            var sch = await convert("Extension", profiles: new[] { TestProfileArtifactSource.PROFILEDORG1 });
             sch.Should().BeASchemaAssertionFor(TestProfileArtifactSource.PROFILEDORG1);
         }
 
         [Fact]
-        public void NakedContainedResourceShouldHaveReferenceValidationAgainstRTT()
+        public async Task NakedContainedResourceShouldHaveReferenceValidationAgainstRTT()
         {
-            var sch = convert("Resource");
+            var sch = await convert("Resource");
             sch.Should().BeASchemaAssertionFor(SchemaReferenceValidator.ForResource);
         }
 
         [Fact]
-        public void ContainedResourceShouldHaveReferenceValidationAgainstProfiles()
+        public async Task ContainedResourceShouldHaveReferenceValidationAgainstProfiles()
         {
-            var sch = convert("Resource", profiles: new[] { TestProfileArtifactSource.PROFILEDPROCEDURE });
+            var sch = await convert("Resource", profiles: new[] { TestProfileArtifactSource.PROFILEDPROCEDURE });
             sch.Should().BeASchemaAssertionFor(TestProfileArtifactSource.PROFILEDPROCEDURE);
         }
 
         [Fact]
-        public void ReferenceOfAnyShouldBuildRTTSchema()
+        public async Task ReferenceOfAnyShouldBuildRTTSchema()
         {
             // This is how a Reference(Any) is encoded in a TypeReference.
             // This should use the runtime type of the target to validate against.
-            var sch = convert("Reference", targets: new[] { "http://hl7.org/fhir/StructureDefinition/Resource" });
+            var sch = await convert("Reference", targets: new[] { "http://hl7.org/fhir/StructureDefinition/Resource" });
             var all = sch.Should().BeOfType<AllValidator>().Subject;
 
             all.Members[1].Should().BeOfType<ReferencedInstanceValidator>()
@@ -169,13 +171,13 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
-        public void ContainedResourceWithAnyShouldBuildRTTSchema()
+        public async Task ContainedResourceWithAnyShouldBuildRTTSchema()
         {
             var resourceUri = "http://hl7.org/fhir/StructureDefinition/Resource";
             // Although this is probably not used, the situation is comparable
             // to a Reference(Any), where the type is "Resource" and the profile is
             // Resource too. This should use the runtime type of the target to validate against.
-            var sch = convert("Resource", profiles: new[] { resourceUri });
+            var sch = await convert("Resource", profiles: new[] { resourceUri });
             sch.Should().BeASchemaAssertionFor(resourceUri);
         }
 
@@ -187,7 +189,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
 #endif
 
 #if STU3
-        private IAssertion? convert(string code, string[]? profiles = null, string[]? targets = null)
+        private Task<IAssertion?> convert(string code, string[]? profiles = null, string[]? targets = null)
         {
             IEnumerable<ElementDefinition.TypeRefComponent> typeRefs = profiles switch
             {
@@ -203,15 +205,15 @@ namespace Firely.Fhir.Validation.Compilation.Tests
                 left.Join(right, x => true, y => true, (l, r) => (l, r));
         }
 #else
-        private IAssertion? convert(string code, string[]? profiles = null, string[]? targets = null)
+        private Task<IAssertion?> convert(string code, string[]? profiles = null, string[]? targets = null)
              => convertTypeReference(build(code, profiles, targets));
 #endif
 
-        private IAssertion? convert(IEnumerable<ElementDefinition.TypeRefComponent> trs) =>
-            new TypeReferenceBuilder(_fixture.ResourceResolver).ConvertTypeReferences(trs);
+        private Task<IAssertion?> convert(IEnumerable<ElementDefinition.TypeRefComponent> trs) =>
+            new TypeReferenceBuilder(_fixture.ResourceResolver).ConvertTypeReferencesAsync(trs);
 
-        private IAssertion? convertTypeReference(ElementDefinition.TypeRefComponent typeRef)
-            => new TypeReferenceBuilder(_fixture.ResourceResolver).ConvertTypeReference(CommonTypeRefComponent.Convert(typeRef));
+        private Task<IAssertion?> convertTypeReference(ElementDefinition.TypeRefComponent typeRef)
+            => new TypeReferenceBuilder(_fixture.ResourceResolver).ConvertTypeReferenceAsync(CommonTypeRefComponent.Convert(typeRef));
     }
 }
 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SlicingSchemaConverterTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SlicingSchemaConverterTests.cs
@@ -33,7 +33,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var sdNav = ElementDefinitionNavigator.ForSnapshot(sd);
             sdNav.MoveToFirstChild();
             Assert.True(sdNav.JumpToFirst(childPath));
-            return await _fixture.Builder.ConvertElement(sdNav);
+            return _fixture.Builder.ConvertElement(sdNav);
         }
 
         private async T.Task<SliceValidator> createSliceForElement(string canonical, string childPath)
@@ -42,7 +42,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var sdNav = ElementDefinitionNavigator.ForSnapshot(sd);
             sdNav.MoveToFirstChild();
             Assert.True(sdNav.JumpToFirst(childPath));
-            var slicev = await _fixture.Builder.CreateSliceValidator(sdNav, default);
+            var slicev = _fixture.Builder.CreateSliceValidator(sdNav);
             return (SliceValidator)slicev;
         }
 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SlicingSchemaConverterTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SlicingSchemaConverterTests.cs
@@ -33,7 +33,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var sdNav = ElementDefinitionNavigator.ForSnapshot(sd);
             sdNav.MoveToFirstChild();
             Assert.True(sdNav.JumpToFirst(childPath));
-            return _fixture.Builder.ConvertElement(sdNav);
+            return await _fixture.Builder.ConvertElement(sdNav);
         }
 
         private async T.Task<SliceValidator> createSliceForElement(string canonical, string childPath)
@@ -42,7 +42,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var sdNav = ElementDefinitionNavigator.ForSnapshot(sd);
             sdNav.MoveToFirstChild();
             Assert.True(sdNav.JumpToFirst(childPath));
-            var slicev = _fixture.Builder.CreateSliceValidator(sdNav);
+            var slicev = await _fixture.Builder.CreateSliceValidator(sdNav, default);
             return (SliceValidator)slicev;
         }
 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ValidatorHighLevelApiTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ValidatorHighLevelApiTests.cs
@@ -12,7 +12,9 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 // Until we have Marco's IScopedNodeOnPoco adapter, I cannot write R5 tests using just the "shared" R4+ validator.
 #if !R5
@@ -48,6 +50,21 @@ namespace Firely.Fhir.Validation.Tests
         }
 
         [Fact]
+        public async Task ValidatesAsyncAndReportsError()
+        {
+            var p = new Patient() { Deceased = new FhirString("wrong") };
+            var validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, null);
+            var result = await validator.ValidateAsync(p, Canonical.ForCoreType("Patient").ToString(), default);
+
+            getErrorCodes(result).Should().ContainSingle(Issue.CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE.Code.ToString());
+            result.Success.Should().BeFalse();
+
+            result = await validator.ValidateAsync(p, null, default);
+            getErrorCodes(result).Should().ContainSingle(Issue.CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE.Code.ToString());
+            result.Success.Should().BeFalse();
+        }
+
+        [Fact]
         public void NoReferenceResolution()
         {
             // First, without a resolver, we do not follow references and thus do not validate the referenced resource.
@@ -59,6 +76,23 @@ namespace Firely.Fhir.Validation.Tests
             var or = new InMemoryExternalReferenceResolver() { ["http://example.com/orgA"] = new Organization() };
             validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, or);
             var result = validator.Validate(p, Canonical.ForCoreType("Patient").ToString());
+
+            // Organization should fail constraint org-1
+            getErrorCodes(result).Should().ContainSingle(Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT.Code.ToString());
+        }
+
+        [Fact]
+        public async Task NoReferenceResolutionAsync()
+        {
+            // First, without a resolver, we do not follow references and thus do not validate the referenced resource.
+            var p = new Patient() { ManagingOrganization = new ResourceReference("http://example.com/orgA") };
+            var validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, null);
+            (await validator.ValidateAsync(p, Canonical.ForCoreType("Patient").ToString(), default)).Success.Should().BeTrue();
+
+            // Now with reference resolution
+            var or = new InMemoryExternalReferenceResolver() { ["http://example.com/orgA"] = new Organization() };
+            validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, or);
+            var result = await validator.ValidateAsync(p, Canonical.ForCoreType("Patient").ToString(), default);
 
             // Organization should fail constraint org-1
             getErrorCodes(result).Should().ContainSingle(Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT.Code.ToString());
@@ -78,6 +112,23 @@ namespace Firely.Fhir.Validation.Tests
             // now, skip constraint validation
             settings.SetSkipConstraintValidation(true);
             result = validator.Validate(o, Canonical.ForCoreType("Organization").ToString());
+            result.Success.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task SkipConstraintValidationAsync()
+        {
+            var o = new Organization();
+            var settings = new ValidationSettings();
+            var validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, settings: settings);
+
+            // validate with constraint validation, it should fail on org-1
+            var result = await validator.ValidateAsync(o, Canonical.ForCoreType("Organization").ToString(), default);
+            getErrorCodes(result).Should().ContainSingle(Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT.Code.ToString());
+
+            // now, skip constraint validation
+            settings.SetSkipConstraintValidation(true);
+            result = await validator.ValidateAsync(o, Canonical.ForCoreType("Organization").ToString(), default);
             result.Success.Should().BeTrue();
         }
     }

--- a/test/Firely.Fhir.Validation.Tests/Impl/CircularReferenceTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/CircularReferenceTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation.Tests
 {
@@ -47,7 +48,7 @@ namespace Firely.Fhir.Validation.Tests
             var resolver = new TestResolver() { SCHEMA };
             var vc = ValidationSettings.BuildMinimalContext(schemaResolver: resolver);
 
-            ITypedElement? resolveExample(string example, string location) =>
+            async Task<ITypedElement?> resolveExample(string example, string location) =>
             example switch
             {
                 "http://example.com/pat1" => pat1,

--- a/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Firely.Fhir.Validation.Tests
 {
@@ -80,7 +81,7 @@ namespace Firely.Fhir.Validation.Tests
                 }
             };
 
-        private static ITypedElement? resolve(string url, string _) =>
+        private static async Task<ITypedElement?> resolve(string url, string _) =>
             url.StartsWith("http://example.com/hit") ?
                 (new { t = "irrelevant" }).DictionaryToTypedElement() : default;
 


### PR DESCRIPTION
addresses #329 

Added new API
```csharp
public class Validator
{
   Task<OperationOutcome> ValidateAsync(ElementNode instance, string? profile, CancellationToken cancellationToken);

   Task<OperationOutcome> ValidateAsync(Resource instance, string? profile, CancellationToken cancellationToken);
}

public interface IElementSchemaResolver
{
   ValueTask<ElementSchema?> GetSchemaAsync(Canonical schemaUri)
      => new(GetSchema(schemaUri));
}


public interface IValidatable
{
   ValueTask<ResultReport?> ValidateAsync(IScopedNode input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
      => new(Validate(input, vc, state));
}


public interface IGroupValidatable
{
   ValueTask<ResultReport?> ValidateAsync(IEnumerable<IScopedNode> input, ValidationSettings vc, ValidationState state, CancellationToken cancellationToken)
      => new(Validate(input, vc, state));
}
``` 

## Tests Added
- Firely.Fhir.Validation.Tests.ValidationDemoTests.RunValidateAsyncTestSuite
- Firely.Fhir.Validation.Tests.ValidatorHighLevelApiTests.NoReferenceResolutionAsync
- Firely.Fhir.Validation.Tests.ValidatorHighLevelApiTests.SkipConstraintValidationAsync
- Firely.Fhir.Validation.Tests.ValidatorHighLevelApiTests.ValidatesAsyncAndReportsError
- Firely.Fhir.Validation.Tests.ResourceSchemaValidationTests.AvoidsRedoingProfileValidationAsync
- Firely.Fhir.Validation.Tests.ResourceSchemaValidationTests.DoesValidateBasedOnActualTypeAsync
- Firely.Fhir.Validation.Tests.ExtensionSchemaValidationTests.UnresolvableExztensionAreJustWarningsAsync