### PR TITLE
Added type coercion between Integer and Integer64

### DIFF
--- a/src/Firely.Fhir.Validation/Impl/MinMaxValueValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/MinMaxValueValidator.cs
@@ -10,6 +10,7 @@ using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.ElementModel.Types;
 using Hl7.Fhir.Support;
 using Hl7.Fhir.Utility;
+using Hl7.FhirPath.Functions;
 using Newtonsoft.Json.Linq;
 using System;
 using System.ComponentModel;
@@ -105,7 +106,15 @@ namespace Firely.Fhir.Validation
 
             try
             {
-                if ((instanceValue is ICqlOrderable ce ? ce.CompareTo(_minMaxAnyValue) : -1) == _comparisonOutcome)
+                var (lt, gt) = (EqualityOperators.Compare(instanceValue, _minMaxAnyValue, "<"), EqualityOperators.Compare(instanceValue, _minMaxAnyValue, ">"));
+                var intResult = (lt, gt) switch
+                {
+                    (true, _) => -1,
+                    (_, false) => 1,
+                    _ => 0
+                };
+                
+                if (intResult == _comparisonOutcome)
                 {
                     return new IssueAssertion(_comparisonIssue, $"Value '{input.Value}' is {_comparisonLabel} {Limit.Value})")
                         .AsResult(s);

--- a/src/Firely.Fhir.Validation/Impl/MinMaxValueValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/MinMaxValueValidator.cs
@@ -110,7 +110,7 @@ namespace Firely.Fhir.Validation
                 var intResult = (lt, gt) switch
                 {
                     (true, _) => -1,
-                    (_, false) => 1,
+                    (false, true) => 1,
                     _ => 0
                 };
                 

--- a/test/Firely.Fhir.Validation.Tests/Impl/MinMaxValueValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/MinMaxValueValidatorTests.cs
@@ -8,11 +8,14 @@
 
 using FluentAssertions;
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.ElementModel.Types;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
+using Date = Hl7.Fhir.Model.Date;
+using Integer = Hl7.Fhir.Model.Integer;
 
 namespace Firely.Fhir.Validation.Tests
 {
@@ -85,6 +88,12 @@ namespace Firely.Fhir.Validation.Tests
                 _validatableMaxValue,
                 PrimitiveTypeExtensions.ToTypedElement<Date, string>("1906"),
                 false, Issue.CONTENT_ELEMENT_PRIMITIVE_VALUE_TOO_LARGE, "PartialGreaterThan"
+            };
+            yield return new object?[]
+            {
+                _validatableMinValue,
+                PrimitiveTypeExtensions.ToTypedElement<Integer64, long?>(4),
+                true, null, "Equals"
             };
         }
     }


### PR DESCRIPTION
R4/R4B attachment.size fields should now correctly perform comparisons even when the type comparison is between an int and a long