### PR TITLE
Upgrade fluent assertions to version 8.0.0

### DIFF
--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -13,7 +13,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="FluentAssertions" Version="7.0.0" />
+		<PackageReference Include="FluentAssertions" Version="8.0.0" />
 		<PackageReference Include="MessagePack" Version="3.1.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.7.1" />

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/Support/FluentAssertionExtensions.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/Support/FluentAssertionExtensions.cs
@@ -22,7 +22,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         /// <typeparam name="TProperty"></typeparam>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static EquivalencyAssertionOptions<TProperty> UsingCanonicalCompare<TProperty>(this EquivalencyAssertionOptions<TProperty> options)
+        public static EquivalencyOptions<TProperty> UsingCanonicalCompare<TProperty>(this EquivalencyOptions<TProperty> options)
             => options.Using<Canonical>(ctx => ctx.Subject.Original.Should().BeEquivalentTo(ctx.Expectation.Original)).WhenTypeIs<Canonical>();
     }
 }


### PR DESCRIPTION
Type renamed from `EquivalencyAssertionOptions` to `EquivalencyOptions`

See: https://fluentassertions.com/releases/#breaking-changes-for-users
