### PR TITLE
Feature/436 split valueset version and uri into separate parameters before validating a code

### DIFF
--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.2</FirelySdkVersion>
+		<FirelySdkVersion>5.11.3</FirelySdkVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.1</FirelySdkVersion>
+		<FirelySdkVersion>5.11.2</FirelySdkVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.1</FirelySdkVersion>
+		<FirelySdkVersion>5.11.2</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.2</FirelySdkVersion>
+		<FirelySdkVersion>5.11.3</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -171,8 +171,11 @@ namespace Firely.Fhir.Validation
             //    it should not generate warnings against the slicing entry.
             if (Strength != BindingStrength.Required) return ResultReport.SUCCESS;
 
+            var vsUri = ValueSetUri.Uri;
+            var vsVersion = ValueSetUri.Version;
+
             var parameters = buildParams()
-                .WithValueSet(ValueSetUri.ToString())
+                .WithValueSet(vsUri, vsVersion)
                 .WithAbstract(AbstractAllowed);
 
             ValidateCodeParameters buildParams()
@@ -187,7 +190,7 @@ namespace Firely.Fhir.Validation
                     Coding cd => vcp.WithCoding(cd),
                     CodeableConcept cc => vcp.WithCodeableConcept(cc),
                     _ => throw Error.InvalidOperation($"Parsed bindable was of unexpected instance type '{bindable.TypeName}'.")
-                }; 
+                };
             }
 
             var display = buildCodingDisplay(parameters);

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -171,11 +171,8 @@ namespace Firely.Fhir.Validation
             //    it should not generate warnings against the slicing entry.
             if (Strength != BindingStrength.Required) return ResultReport.SUCCESS;
 
-            var vsUri = ValueSetUri.Uri;
-            var vsVersion = ValueSetUri.Version;
-
             var parameters = buildParams()
-                .WithValueSet(vsUri, vsVersion)
+                .WithValueSet(new Hl7.Fhir.Model.Canonical(ValueSetUri.ToString())) //This should be cleaned up once we have one common Canonical type. 
                 .WithAbstract(AbstractAllowed);
 
             ValidateCodeParameters buildParams()


### PR DESCRIPTION
Fixes #436 

Take a look at:https://github.com/FirelyTeam/fhir-test-cases/pull/56 first.
