### PR TITLE
DEVOPS-354: Use v1 of Firely Azure templates

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -25,7 +25,8 @@ resources:
   - repository: templates
     type: github
     name: FirelyTeam/azure-pipeline-templates
-    endpoint: FirelyTeam 
+    endpoint: FirelyTeam
+    ref: refs/tags/v1
 
 stages:
 - stage: build


### PR DESCRIPTION
## Description
Use version `v1` (base version) of the Firely Azure templates (FirelyTeam/azure-pipeline-templates).

## Testing
- If you have added a new test, mention it here.
- If you have only changed builders and decided not to write a test, make sure the new schema snapshots reflect your changes.
