### PR TITLE
Use the right variable syntax

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -53,7 +53,8 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', variables.FIRELY_SDK_VERSION ) }} #coerce the value into a string to avoid issue with template expression
+          ${{ if ne(variables['firelySDKVersion'], '') }}:
+            packageVersion: $(firelySDKVersion)
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -61,7 +62,8 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', variables.FIRELY_SDK_VERSION ) }} #coerce the value into a string to avoid issue with template expression
+          ${{ if ne(variables['firelySDKVersion'], '') }}:
+            packageVersion: $(firelySDKVersion)
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -50,6 +50,8 @@ stages:
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:
+      - powershell: |
+          Write-Host "FIRELY_SDK_VERSION: [$(FIRELY_SDK_VERSION)]"
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
   - group: CodeSigning
   - group: APIKeys
   - template: variables.yml
-  - name: FIRELY_SDK_VERSION
-    value: $[coalesce(variables['firelySDKVersion'], '')]
 
 pool: 
   vmImage: $(vmImage)
@@ -50,12 +48,10 @@ stages:
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:
-      - powershell: |
-          Write-Host "FIRELY_SDK_VERSION: [$(FIRELY_SDK_VERSION)]"
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: $(FIRELY_SDK_VERSION)
+          packageVersion: $(firelySDKVersion)
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -63,7 +59,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: $(FIRELY_SDK_VERSION)
+          packageVersion: $(firelySDKVersion)
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -48,6 +48,9 @@ stages:
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:
+      - powershell: |
+          Write-Host "firelySDKVersion:  $(firelySDKVersion)"
+          Write-Host "firelySDKVersion: ${{ variables.firelySDKVersion}}"
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -12,6 +12,8 @@ variables:
   - group: CodeSigning
   - group: APIKeys
   - template: variables.yml
+  - name: FIRELY_SDK_VERSION
+    value: $[coalesce(variables['firelySDKVersion'], '')]
 
 pool: 
   vmImage: $(vmImage)
@@ -51,7 +53,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: $[coalesce(variables['firelySDKVersion'], '')]
+          packageVersion: $(FIRELY_SDK_VERSION)
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -59,7 +61,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: $[coalesce(variables['firelySDKVersion'], '')]
+          packageVersion: $(FIRELY_SDK_VERSION)
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', variables.firelySDKVersion) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', $(firelySDKVersion) ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -62,7 +62,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', variables.firelySDKVersion) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', $(firelySDKVersion) ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
   - group: CodeSigning
   - group: APIKeys
   - template: variables.yml
-  - name: FIRELY_SDK_VERSION
-    value: $(firelySDKVersion) # managed in the UI by the Firely SDK build pipeline 
 
 pool: 
   vmImage: $(vmImage)
@@ -53,8 +51,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          ${{ if ne(variables['firelySDKVersion'], '') }}:
-            packageVersion: $(firelySDKVersion)
+          packageVersion: $[coalesce(variables['firelySDKVersion'], '')]
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -62,8 +59,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          ${{ if ne(variables['firelySDKVersion'], '') }}:
-            packageVersion: $(firelySDKVersion)
+          packageVersion: $[coalesce(variables['firelySDKVersion'], '')]
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', $(firelySDKVersion) ) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', '$(firelySDKVersion)' ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -62,7 +62,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', $(firelySDKVersion) ) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', '$(firelySDKVersion)' ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -11,7 +11,9 @@ resources:
 variables:
   - group: CodeSigning
   - group: APIKeys
-  - template: variables.yml 
+  - template: variables.yml
+  - name: FIRELY_SDK_VERSION
+    value: $(firelySDKVersion) # managed in the UI by the Firely SDK build pipeline 
 
 pool: 
   vmImage: $(vmImage)
@@ -51,7 +53,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', '$(firelySDKVersion)' ) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', variables.FIRELY_SDK_VERSION ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed
@@ -59,7 +61,7 @@ stages:
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'
-          packageVersion: ${{ format('{0}', '$(firelySDKVersion)' ) }} #coerce the value into a string to avoid issue with template expression
+          packageVersion: ${{ format('{0}', variables.FIRELY_SDK_VERSION ) }} #coerce the value into a string to avoid issue with template expression
           propertyFilePath: 'firely-validator-api-tests.props'
           packageProperty: 'FirelySdkVersion'
           nuGetServiceConnections: GitHubPackageGetFeed

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,7 +7,7 @@ resources:
     type: github
     name: FirelyTeam/azure-pipeline-templates
     endpoint: FirelyTeam
-    ref: refs/head/fix/updatePackageVersion
+    ref: refs/heads/fix/updatePackageVersion
 variables:
   - group: CodeSigning
   - group: APIKeys

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,7 +7,7 @@ resources:
     type: github
     name: FirelyTeam/azure-pipeline-templates
     endpoint: FirelyTeam
-    ref: refs/heads/fix/updatePackageVersion
+    ref: refs/tags/v1
 variables:
   - group: CodeSigning
   - group: APIKeys

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -7,7 +7,7 @@ resources:
     type: github
     name: FirelyTeam/azure-pipeline-templates
     endpoint: FirelyTeam
-    ref: refs/tags/v1
+    ref: refs/head/fix/updatePackageVersion
 variables:
   - group: CodeSigning
   - group: APIKeys

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -48,9 +48,6 @@ stages:
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:
-      - powershell: |
-          Write-Host "firelySDKVersion:  $(firelySDKVersion)"
-          Write-Host "firelySDKVersion: ${{ variables.firelySDKVersion}}"
       - template: updatePackageVersion.yml@templates
         parameters:
           packageName: 'Hl7.Fhir.Base'


### PR DESCRIPTION
Use the right variable syntax for passing the variable `firelySDKVersion` to the template updatePackageVersion.

:warning: first PR should be approved before merging this [PR](https://github.com/FirelyTeam/azure-pipeline-templates/pull/42).