### PR TITLE
Fetch the invariants for base types that aren't sliced

### DIFF
--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.6</FirelySdkVersion>
+		<FirelySdkVersion>5.11.7</FirelySdkVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<FirelySdkVersion>5.11.6</FirelySdkVersion>
+		<FirelySdkVersion>5.11.7</FirelySdkVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -167,6 +167,14 @@ namespace Firely.Fhir.Validation.Compilation
                 {
                     var childrenAssertion = createChildrenAssertion(nav, subschemas);
                     schemaMembers.Add(childrenAssertion);
+                    
+                    // type we're working with was pulled into definition, and we're not in a slice
+                    // so we need to validate any invariant rules we might find as well.
+                    // We can skip backbone elements though, as there's nothing to copy.
+                    if (schemaMembers.OfType<BaseType>().Any() && string.IsNullOrEmpty(nav.Current.SliceName) && !nav.Current.IsBackboneElement()) 
+                    {
+                        schemaMembers.Add(new BaseTypeInvariantConstraintsValidator());
+                    }
                 }
 
                 // Slicing also needs to navigate to its sibling ElementDefinitions,

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -168,7 +168,10 @@ namespace Firely.Fhir.Validation.Compilation
                     var childrenAssertion = createChildrenAssertion(nav, subschemas);
                     schemaMembers.Add(childrenAssertion);
                     
-                    // type we're working with was pulled into definition, and we're not in a slice
+                    // This is a temporary hack for the issue where snapshot generator won't copy the invariants from base when pulling all children into the ElementDefinitionNavigator.
+                    // Extra details in this issue https://github.com/FirelyTeam/firely-validator-api/issues/491#issuecomment-2897145768
+                    // Should be cleaned up once https://github.com/FirelyTeam/firely-net-sdk/issues/3156 is solved
+                    // Type we're working with was pulled into definition, and we're not in a slice
                     // so we need to validate any invariant rules we might find as well, but we shouldn't pull them twice.
                     // We can skip backbone elements though, as there's nothing to copy.
                     if (schemaMembers.OfType<BaseType>().Any() && !schemaMembers.OfType<FhirPathValidator>().Any()

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -169,9 +169,10 @@ namespace Firely.Fhir.Validation.Compilation
                     schemaMembers.Add(childrenAssertion);
                     
                     // type we're working with was pulled into definition, and we're not in a slice
-                    // so we need to validate any invariant rules we might find as well.
+                    // so we need to validate any invariant rules we might find as well, but we shouldn't pull them twice.
                     // We can skip backbone elements though, as there's nothing to copy.
-                    if (schemaMembers.OfType<BaseType>().Any() && string.IsNullOrEmpty(nav.Current.SliceName) && !nav.Current.IsBackboneElement()) 
+                    if (schemaMembers.OfType<BaseType>().Any() && !schemaMembers.OfType<FhirPathValidator>().Any()
+                        && string.IsNullOrEmpty(nav.Current.SliceName) && !nav.Current.IsBackboneElement()) 
                     {
                         schemaMembers.Add(new BaseTypeInvariantConstraintsValidator());
                     }

--- a/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
@@ -1,0 +1,45 @@
+using Newtonsoft.Json.Linq;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation;
+
+/// <summary>
+/// An assertion which validates the FhirPath rules of the type only.
+/// </summary>
+[DataContract]
+[EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+[System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+internal class BaseTypeInvariantConstraintsValidator : IValidatable
+{
+    /// <summary>
+    /// Validate input against the expected context and invariants.
+    /// </summary>
+    /// <param name="input"></param>
+    /// <param name="vc"></param>
+    /// <param name="state"></param>
+    /// <returns></returns>
+    public ResultReport Validate(IScopedNode input, ValidationSettings vc, ValidationState state)
+    {
+        if(input.InstanceType is null)
+            throw new ArgumentException($"Cannot validate the resource because {nameof(IScopedNode)} does not have an instance type.");
+        
+        return FhirSchemaGroupAnalyzer.FetchSchema(vc.ElementSchemaResolver, state, vc.TypeNameMapper.MapTypeName(input.InstanceType)) switch
+        {
+            (var schema, null, _) => ResultReport.Combine(schema!.Members.OfType<FhirPathValidator>().Select(x => x.ValidateOne(input, vc, state)).ToList()),
+            (_, var error, _) => error
+        };
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <returns></returns>
+    public JToken ToJson() => new JProperty("baseTypeInvariants", new JObject());
+}

--- a/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
@@ -9,6 +9,12 @@ namespace Firely.Fhir.Validation;
 /// <summary>
 /// An assertion which validates the FhirPath rules of the type only.
 /// </summary>
+/// <remarks>
+/// This is a temporary hack for the issue where snapshot generator won't copy the invariants from base when pulling all children into the ElementDefinitionNavigator.
+///
+/// Extra details in this issue https://github.com/FirelyTeam/firely-validator-api/issues/491#issuecomment-2897145768
+/// Remove once https://github.com/FirelyTeam/firely-net-sdk/issues/3156 is solved
+/// </remarks>
 [DataContract]
 [EditorBrowsable(EditorBrowsableState.Never)]
 #if NET8_0_OR_GREATER
@@ -27,9 +33,9 @@ internal class BaseTypeInvariantConstraintsValidator : IValidatable
     /// <returns></returns>
     public ResultReport Validate(IScopedNode input, ValidationSettings vc, ValidationState state)
     {
-        if(input.InstanceType is null)
+        if (input.InstanceType is null)
             throw new ArgumentException($"Cannot validate the resource because {nameof(IScopedNode)} does not have an instance type.");
-        
+
         return FhirSchemaGroupAnalyzer.FetchSchema(vc.ElementSchemaResolver, state, vc.TypeNameMapper.MapTypeName(input.InstanceType)) switch
         {
             (var schema, null, _) => ResultReport.Combine(schema!.Members.OfType<FhirPathValidator>().Select(x => x.ValidateOne(input, vc, state)).ToList()),

--- a/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
@@ -38,7 +38,7 @@ internal class BaseTypeInvariantConstraintsValidator : IValidatable
 
         return FhirSchemaGroupAnalyzer.FetchSchema(vc.ElementSchemaResolver, state, vc.TypeNameMapper.MapTypeName(input.InstanceType)) switch
         {
-            (var schema, null, _) => ResultReport.Combine(schema!.Members.OfType<FhirPathValidator>().Select(x => x.ValidateOne(input, vc, state)).ToList()),
+            (var schema, null, _) => ResultReport.Combine(schema!.Members.Where(vc.Filter).OfType<FhirPathValidator>().Select(x => x.ValidateOne(input, vc, state)).ToList()),
             (_, var error, _) => error
         };
     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -230,6 +230,30 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             results.IsSuccessful.Should().Be(false, "The element 'div' in namespace 'http://www.w3.org/1999/xhtml' has invalid child element 'script' in namespace 'http://www.w3.org/1999/xhtml'. List of possible elements expected: 'p, h1, h2, h3, h4, h5, h6, div, ul, ol, dl, pre, hr, blockquote, address, table, a, br, span, bdo, map, img, tt, i, b, big, small, em, strong, dfn, code, q, samp, kbd, var, cite, abbr, acronym, sub, sup' in namespace 'http://www.w3.org/1999/xhtml'.");
 
         }
+        
+        [Theory]
+        [InlineData(TestProfileArtifactSource.PROFILEDEXTENSIONTYPEWITHCHILDREN)]
+        [InlineData(TestProfileArtifactSource.PROFILEDEXTENSIONTYPEWITHSLICE)]
+        public void ValidateProfiledRunsInvariants(string url)
+        {
+            var carePlan = new CarePlan()
+            {
+#if STU3
+                Status = CarePlan.CarePlanStatus.Active,
+#else
+                Status = RequestStatus.Active,
+#endif
+                Intent = CarePlan.CarePlanIntent.Plan,
+                Subject = new ResourceReference("Patient/example"),
+                Extension = [ new(url, new Period(new("2017-06-02"), new("2017-06-01")))]
+            };
+            
+            var schema = _fixture.SchemaResolver.GetSchema(Canonical.ForCoreType(carePlan.TypeName))!;
+            var result = schema.Validate(carePlan.ToTypedElement(), _fixture.NewValidationSettings());
+            var oo = result.ToOperationOutcome();
+            oo.Success.Should().Be(false);
+            oo.Issue[0].Details.Text.Should().Contain("Instance failed constraint per-1");
+        }
 
         [Fact]
         public void ValidateUriStringsInExtension()

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
@@ -45,6 +45,9 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         public const string BUNDLEWITHCONSTRAINEDCONTAINED = "http://validationtest.org/fhir/StructureDefinition/BundleWithConstrainedContained";
         
         public const string CONTEXTCONSTRAINEDEXTENSION = "http://validationtest.org/fhir/StructureDefinition/ConstrainedExtensionContext";
+        
+        public const string PROFILEDEXTENSIONTYPEWITHCHILDREN = "http://validationtest.org/fhir/StructureDefinition/ExtensionValueXChildren";
+        public const string PROFILEDEXTENSIONTYPEWITHSLICE = "http://validationtest.org/fhir/StructureDefinition/ExtensionValuePeriodSlice";
 
 
         public List<StructureDefinition> TestProfiles =
@@ -75,8 +78,29 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             buildPatientWithProfiledReferences(),
             bundleWithConstrainedContained(),
             buildProfiledEncounter(),
-            buildContextConstrainedExtension()
+            buildContextConstrainedExtension(),
+            buildExtensionValueChildConstraints(PROFILEDEXTENSIONTYPEWITHCHILDREN, "value[x]"),
+            buildExtensionValueChildConstraints(PROFILEDEXTENSIONTYPEWITHSLICE, "valuePeriod"),
         ];
+        
+        private static StructureDefinition buildExtensionValueChildConstraints(string uri, string property)
+        {
+            var result = createTestSD(
+                uri, 
+                $"Extension constraining value[x] to Period and makes {property}.start mandatory", 
+                $"Extension constraining value[x] to Period and makes {property}.start mandatory", 
+                FHIRAllTypes.Extension
+            );
+
+            result.Differential.Element =
+            [
+                new("Extension.url") { Type = [ new() { Code = "uri" } ], Fixed = new FhirUri(uri) },
+                new("Extension.value[x]") { Type = [ new() { Code = "Period" } ], Min = 1, Max = "1" },
+                new($"Extension.{property}.start") { Min = 1 }
+            ];
+            
+            return result;
+        }
 
         private static StructureDefinition buildProfiledEncounter()
         {


### PR DESCRIPTION
## Description
Ensures we won't miss a constraint from a type that had it's children pulled into the definition.

## Related issues
Closes #491