### PR TITLE
Enable external reference resolving in `FhirPathValidator`

### DIFF
--- a/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
@@ -114,10 +114,12 @@ namespace Firely.Fhir.Validation
         {
             try
             {
+                Func<string, ITypedElement?>? resolver = vc.ResolveExternalReference is null ? null : element => vc.ResolveExternalReference.Invoke(element, input.Location);
                 var context = new FhirEvaluationContext
                 {
                     TerminologyService = new ValidateCodeServiceToTerminologyServiceAdapter(vc.ValidateCodeService),
-                    Environment = new Dictionary<string, IEnumerable<ITypedElement>>(env.Select(kvp => new KeyValuePair<string, IEnumerable<ITypedElement>>(kvp.key, kvp.value)))
+                    Environment = new Dictionary<string, IEnumerable<ITypedElement>>(env.Select(kvp => new KeyValuePair<string, IEnumerable<ITypedElement>>(kvp.key, kvp.value))),
+                    ElementResolver = resolver
                 };
                 
                 var success = predicate(input, context, vc);

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
@@ -48,6 +48,8 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         
         public const string PROFILEDEXTENSIONTYPEWITHCHILDREN = "http://validationtest.org/fhir/StructureDefinition/ExtensionValueXChildren";
         public const string PROFILEDEXTENSIONTYPEWITHSLICE = "http://validationtest.org/fhir/StructureDefinition/ExtensionValuePeriodSlice";
+        
+        public const string PROFILEDINVARIANTRESOLVE = "http://validationtest.org/fhir/StructureDefinition/ObservationSubjectPatientActive";
 
 
         public List<StructureDefinition> TestProfiles =
@@ -81,7 +83,33 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             buildContextConstrainedExtension(),
             buildExtensionValueChildConstraints(PROFILEDEXTENSIONTYPEWITHCHILDREN, "value[x]"),
             buildExtensionValueChildConstraints(PROFILEDEXTENSIONTYPEWITHSLICE, "valuePeriod"),
+            buildExtensionValueChildConstraints(),
         ];
+        
+        private static StructureDefinition buildExtensionValueChildConstraints()
+        {
+            var result = createTestSD(
+            PROFILEDINVARIANTRESOLVE, 
+            $"Invariant requiring Observation.subject to be an active patient", 
+            $"Invariant requiring Observation.subject to be an active patient", 
+            FHIRAllTypes.Observation
+            );
+
+            result.Differential.Element =
+            [
+                new("Observation") { Constraint = [ 
+                    new()
+                    {
+                        Severity = ConstraintSeverity.Error,
+                        Key = "obs-test",
+                        Expression = "subject.resolve().ofType(Patient).active = true",
+                        Human = "Test invariant"
+                    }
+                ] },
+            ];
+            
+            return result;
+        }
         
         private static StructureDefinition buildExtensionValueChildConstraints(string uri, string property)
         {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
@@ -100,7 +100,11 @@ namespace Firely.Fhir.Validation.Compilation.Tests
                 new("Observation") { Constraint = [ 
                     new()
                     {
+                        #if STU3
+                        Severity = ElementDefinition.ConstraintSeverity.Error,
+                        #else
                         Severity = ConstraintSeverity.Error,
+                        #endif
                         Key = "obs-test",
                         Expression = "subject.resolve().ofType(Patient).active = true",
                         Human = "Test invariant"

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ValidatorHighLevelApiTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/ValidatorHighLevelApiTests.cs
@@ -66,6 +66,24 @@ namespace Firely.Fhir.Validation.Tests
         }
 
         [Fact]
+        public void ReferenceResolutionInFhirPath()
+        {
+            var or = new InMemoryExternalReferenceResolver();
+            var p = new Observation()
+            {
+                Status = ObservationStatus.Final,
+                Code = new() { Text = "something" },
+                Meta = new() { Profile = [ TestProfileArtifactSource.PROFILEDINVARIANTRESOLVE ] }, Subject = new ResourceReference("http://example.com/Pat1")
+            };
+            var validator = new Validator(_fixture.ResourceResolver, _fixture.ValidateCodeService, or);
+            var result =  validator.Validate(p);
+            result.Success.Should().BeFalse();
+            or.Add("http://example.com/Pat1", new Patient() { Active = true });
+            result =  validator.Validate(p);
+            result.Success.Should().BeTrue();
+        }
+
+        [Fact]
         public void SkipConstraintValidation()
         {
             var o = new Organization();


### PR DESCRIPTION
Allows for resolving external references while validating FhirPath expressions using the `ExternalReferenceResolver` from validation settings.