### PR TITLE
Minor fixes from FS

### DIFF
--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -2,7 +2,7 @@
 
     <!-- Solution-wide properties for NuGet packaging -->
     <PropertyGroup>
-        <VersionPrefix>2.7.0</VersionPrefix>
+        <VersionPrefix>2.8.0</VersionPrefix>
         <VersionSuffix>alpha</VersionSuffix>
         <Authors>Firely</Authors>
         <Company>Firely (https://fire.ly)</Company>

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/PatternBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/PatternBuilder.cs
@@ -30,10 +30,7 @@ namespace Firely.Fhir.Validation.Compilation
             var def = nav.Current;
 
             if (def.Pattern is not null)
-            {
-                var inspector = ModelInspector.ForType(def.Pattern.GetType());
                 yield return new PatternValidator(def.Pattern.ToPocoNode());
-            }
         }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/ExtensionContextValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ExtensionContextValidator.cs
@@ -139,6 +139,8 @@ public class ExtensionContextValidator : IValidatable
         }
         
         if(current == null) return false;
+        if(type == current.Poco.TypeName) return true;
+        
 #pragma warning disable CS0618 // Type or member is obsolete
         var modelInspector = ModelInspector.ForType(current.Poco.GetType());
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation/Impl/PatternValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/PatternValidator.cs
@@ -51,15 +51,19 @@ namespace Firely.Fhir.Validation
         /// <inheritdoc/>
         ResultReport IValidatable.Validate(PocoNode input, ValidationSettings _, ValidationState s)
         {
-            var result = input.Matches(PatternValue)
-              ? ResultReport.SUCCESS
-              : new IssueAssertion(Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE, $"Value '{displayValue(input)}' does not match pattern '{displayValue(PatternValue)}'")  // TODO: add value to message
+            if (input.Matches(PatternValue))
+                return ResultReport.SUCCESS;
+                    
+            var severity = OperationOutcome.IssueSeverity.Error;
+            // element with no value and extension - might have a special meaning, so let's make it into warning instead
+            if (input.GetValue() is null && (input.Poco as IExtendable)?.HasExtensions() is true)
+                severity = OperationOutcome.IssueSeverity.Warning;
+                    
+            return new IssueAssertion(Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE.Code, $"Value '{displayValue(input)}' does not match pattern '{displayValue(PatternValue)}'", severity, OperationOutcome.IssueType.Invalid)
                   .AsResult(s, input, nameof(PatternValidator));
 
-            return result;
-
             static string displayValue(ITypedElement te) =>
-              te.Children().Any() ? te.ToJson() : te.Value!.ToString()!;
+              te.Children().Any() ? te.ToJson() : te.Value?.ToString()!;
         }
 
         /// <inheritdoc/>

--- a/src/Firely.Fhir.Validation/Impl/PatternValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/PatternValidator.cs
@@ -56,7 +56,7 @@ namespace Firely.Fhir.Validation
                     
             var severity = OperationOutcome.IssueSeverity.Error;
             // element with no value and extension - might have a special meaning, so let's make it into warning instead
-            if (input.GetValue() is null && (input.Poco as IExtendable)?.HasExtensions() is true)
+            if (input is PrimitiveNode && input.GetValue() is null && (input.Poco as IExtendable)?.HasExtensions() is true)
                 severity = OperationOutcome.IssueSeverity.Warning;
                     
             return new IssueAssertion(Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE.Code, $"Value '{displayValue(input)}' does not match pattern '{displayValue(PatternValue)}'", severity, OperationOutcome.IssueType.Invalid)

--- a/src/Firely.Fhir.Validation/Impl/RegExValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/RegExValidator.cs
@@ -57,20 +57,23 @@ namespace Firely.Fhir.Validation
         internal override ResultReport BasicValidate(PocoNode input, ValidationSettings _, ValidationState s)
         {
             var value = toStringRepresentation(input);
-            // element with no value and extension is allowed, or it has to match the regex
-            var success = value is null || _regex.Match(value).Success;
+            if (value is not null && _regex.IsMatch(value))
+                return ResultReport.SUCCESS;
 
-            return !success
-                ? new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, $"Value '{value}' does not match regex '{Pattern}'")
-                    .AsResult(s, input, nameof(RegExValidator))
-                : ResultReport.SUCCESS;
+            var severity = OperationOutcome.IssueSeverity.Error;
+            // element with no value and extension - might have a special meaning, so let's make it into warning instead
+            if (value is null && (input.Poco as IExtendable)?.HasExtensions() is true)
+                severity = OperationOutcome.IssueSeverity.Warning;
+
+            return new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE.Code, $"Value '{value}' does not match regex '{Pattern}'", severity, OperationOutcome.IssueType.Invalid)
+                .AsResult(s, input, nameof (RegExValidator));
         }
 
         private static string? toStringRepresentation(PocoNode vp)
         {
-            return vp == null || vp.GetValue() == null ?
-                null :
-                PrimitiveTypeConverter.ConvertTo<string>(vp.GetValue());
+            return vp?.GetValue() is { } value ?
+                PrimitiveTypeConverter.ConvertTo<string>(value)
+                : null;
         }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/RegExValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/RegExValidator.cs
@@ -57,7 +57,8 @@ namespace Firely.Fhir.Validation
         internal override ResultReport BasicValidate(PocoNode input, ValidationSettings _, ValidationState s)
         {
             var value = toStringRepresentation(input);
-            var success = value is not null && _regex.Match(value).Success;
+            // element with no value and extension is allowed, or it has to match the regex
+            var success = value is null || _regex.Match(value).Success;
 
             return !success
                 ? new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, $"Value '{value}' does not match regex '{Pattern}'")

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -67,6 +67,19 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         }
 
         [Fact]
+        public void ValidateDateWithNoValueAndExtension()
+        {
+            var date = new Date() { Extension = [new("http://hl7.org/fhir/StructureDefinition/patient-birthTime", new FhirDateTime("1974-12-25T14:35:45-05:00"))] }.ToPocoNode();
+
+            var dateSchema = _fixture.SchemaResolver.GetSchema("http://hl7.org/fhir/StructureDefinition/Date");
+
+            var results = dateSchema!.Validate(date, _fixture.NewValidationSettings());
+
+            results.Should().NotBeNull();
+            results.IsSuccessful.Should().BeTrue("null value is allowed for date regex");
+        }
+
+        [Fact]
         public void PatientHumanNameTooLong()
         {
             var poco = new Patient() { Name = new List<HumanName>() { new HumanName() { Family = bigString() } } };

--- a/test/Firely.Fhir.Validation.Tests/Impl/PatternValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/PatternValidatorTests.cs
@@ -85,6 +85,19 @@ namespace Firely.Fhir.Validation.Tests
                 ElementNodeAdapterExtensions.CreateHumanName("Brown", Array.Empty<string>() ),
                 false, Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE, "The input should not match the pattern"
             };
+            yield return new object?[]
+            {
+                new PatternValidator(new Date("2022-02-02").ToPocoNode()),
+                new Date() { Extension = [new("http://test", new FhirString("Test"))]}.ToPocoNode(),
+                true, Issue.Create(Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE.Code, OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Invalid),
+                "Primitive input with extension and no value will generate a warning."
+            };
+            yield return new object?[]
+            {
+                new PatternValidator(new CodeableConcept("test-system", "test-code").ToPocoNode()),
+                new CodeableConcept() { Coding = [new() { CodeElement = new() { Extension = [new("http://test", new FhirString("Test"))]}}]}.ToPocoNode(),
+                false, Issue.CONTENT_DOES_NOT_MATCH_PATTERN_VALUE, "Complex inputs primitive entry with extension and no value will still generate an error."
+            };
         }
     }
 


### PR DESCRIPTION
Regex on a null value + extension should not result in a failure - perhaps the extension has special meaning for value being missing, so we'll make it a warning instead.
The extension context validator need not look up runtime types if it is the exact type already.