### PR TITLE
Add big validation bundle, enable cross version benchmarking

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -3,79 +3,41 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
+        <TargetFrameworks>net8.0</TargetFrameworks>
 		<AssemblyName>Benchmarks</AssemblyName>
 		<RootNamespace>Firely.Fhir.Validation.Benchmarks</RootNamespace>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
+        <DefineConstants>PROJECT;VALSDK6</DefineConstants>
 	</PropertyGroup>
-
+    
 	<ItemGroup>
-		<None Remove="TestData\DocumentComposition\DocumentBundle.structuredefinition.xml" />
-		<None Remove="TestData\DocumentComposition\DocumentComposition.structuredefinition.xml" />
-		<None Remove="TestData\DocumentComposition\HeightQuantity.structuredefinition.xml" />
-		<None Remove="TestData\DocumentComposition\Hippocrates.practitioner.xml" />
-		<None Remove="TestData\DocumentComposition\Levin.patient.xml" />
-		<None Remove="TestData\DocumentComposition\MainBundle.bundle.xml" />
-		<None Remove="TestData\DocumentComposition\manifest.json" />
-		<None Remove="TestData\DocumentComposition\patient-clinicalTrial.xml" />
-		<None Remove="TestData\DocumentComposition\SectionTitles.valueset.xml" />
-		<None Remove="TestData\DocumentComposition\Weight.observation.xml" />
-		<None Remove="TestData\DocumentComposition\WeightHeightObservation.structuredefinition.xml" />
-		<None Remove="TestData\DocumentComposition\WeightQuantity.structuredefinition.xml" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Content Include="TestData\DocumentComposition\DocumentBundle.structuredefinition.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\DocumentComposition.structuredefinition.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\HeightQuantity.structuredefinition.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\Hippocrates.practitioner.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\Levin.patient.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\MainBundle.bundle.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\manifest.json">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\patient-clinicalTrial.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\SectionTitles.valueset.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\Weight.observation.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\WeightHeightObservation.structuredefinition.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="TestData\DocumentComposition\WeightQuantity.structuredefinition.xml">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
+        <Content Include="TestData\DocumentComposition\*.xml">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="TestData\**\*.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Hl7.Fhir.Base" Version="$(FirelySdkVersion)" />
-		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Firely.Fhir.Validation.R4\Firely.Fhir.Validation.R4.csproj" />
-	</ItemGroup>
+    <ItemGroup Condition="$(DefineConstants.Contains('PROJECT'))">
+        <ProjectReference Include="..\..\src\Firely.Fhir.Validation.R4\Firely.Fhir.Validation.R4.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK5'))">
+        <PackageReference Include="Firely.Fhir.Validation.R4" Version="2.7.0" />
+        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="5.12.1" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK6'))">
+        <PackageReference Include="Firely.Fhir.Validation.R4" Version="2.8.0-alpha-20250905.1" />
+        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="6.0.0-rc2-20250915.4" />
+    </ItemGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
 		<SignAssembly>True</SignAssembly>

--- a/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
+++ b/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
@@ -1,0 +1,73 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
+{
+    private record PackageVersion(string Version, string? Constant = null, bool Baseline = false);
+    private readonly static string[] ALL_VERSIONS = [
+        "2.7.0",
+        "2.8.0-alpha-20250905.1"
+    ];
+
+    private const string PACKAGE = "Firely.Fhir.Validation.R4";
+
+    public CrossVersionConfigurationAttribute(Type benchmarkType, bool displayGenColumns = false)
+    {
+        var attributes = benchmarkType.GetCustomAttributes(typeof(PackageVersionAttribute), false);
+        var versions = attributes.OfType<PackageVersionAttribute>().Select(x=> new PackageVersion(x.PackageVersion, x.Constant, x.Baseline)).Distinct().ToList();
+        
+        if (versions.Count == 0)
+            versions.AddRange(ALL_VERSIONS.Select(x => new PackageVersion(x)));
+        
+        Config = ManualConfig.CreateEmpty()
+            .AddDiagnoser(new MemoryDiagnoser(new(displayGenColumns)))
+            .HideColumns(BenchmarkDotNet.Columns.Column.Arguments, BenchmarkDotNet.Columns.Column.NuGetReferences)
+            .AddJob([..buildJobsFromVersions(versions)]);
+        
+        if (benchmarkType.GetCustomAttribute(typeof(ProjectReferenceAttribute)) is not null)
+            Config = Config.AddJob(Job.Default.WithId("Current Branch"));
+    }
+
+    private static IEnumerable<Job> buildJobsFromVersions(IEnumerable<PackageVersion> versions)
+    {
+        foreach (var major in versions.ToLookup(x => x.Version[0]+x.Version[2]))
+        {
+            List<Argument> args = GetArgsFor($"VAL{major.Key}");
+            foreach (var version in major)
+            {
+                var job = Job.Default
+                    .WithId(version.Version)
+                    .WithArguments(version.Constant is null ? args : GetArgsFor(version.Constant))
+                    // will upgrade the version defined in csproj to a specified version
+                    .WithNuGet(PACKAGE, version.Version);
+
+                if (version.Baseline)
+                    yield return job.AsBaseline();
+                else
+                    yield return job;
+            }
+        }
+
+    }
+
+    static List<Argument> GetArgsFor(string constant)
+    {
+        return [new MsBuildArgument($"/p:DefineConstants={constant}")];
+    }
+    
+    public IConfig Config { get; }
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public class PackageVersionAttribute(string PackageVersion) : Attribute
+{
+    public string PackageVersion { get; } = PackageVersion;
+    public string? Constant { get; set; } = null;
+    public bool Baseline { get; set; } = false;
+}
+public class ProjectReferenceAttribute : Attribute;

--- a/test/Benchmarks/IsExternalInit.cs
+++ b/test/Benchmarks/IsExternalInit.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+
+// Needed for pre-net5 targets to support "init"-type setters (C# 9.0).
+// See also https://github.com/dotnet/roslyn/issues/45510
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/test/Benchmarks/TestData/ValidationBundle.json
+++ b/test/Benchmarks/TestData/ValidationBundle.json
@@ -1,0 +1,126 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-benchmark-80",
+  "type": "collection",
+  "entry": [
+    { "fullUrl": "Patient/patient-1", "resource": { "resourceType": "Patient", "id": "patient-1", "name": [{ "family": "Testpatient", "given": ["Alice"] }], "gender": "female", "birthDate": "1980-01-15" } },
+    { "fullUrl": "Practitioner/practitioner-1", "resource": { "resourceType": "Practitioner", "id": "practitioner-1", "name": [{ "family": "Smith", "given": ["John"] }], "qualification": [{ "code": { "text": "MD" } }] } },
+    { "fullUrl": "Organization/organization-1", "resource": { "resourceType": "Organization", "id": "organization-1", "name": "Acme Healthcare" } },
+    { "fullUrl": "Observation/observation-1", "resource": { "resourceType": "Observation", "id": "observation-1", "status": "final", "code": { "text": "Blood pressure" }, "subject": { "reference": "Patient/patient-1" }, "effectiveDateTime": "2025-09-15T08:30:00+02:00", "valueQuantity": { "value": 120, "unit": "mmHg" } } },
+    { "fullUrl": "Condition/condition-1", "resource": { "resourceType": "Condition", "id": "condition-1", "code": { "text": "Hypertension" }, "subject": { "reference": "Patient/patient-1" } } },
+    { "fullUrl": "Encounter/encounter-1", "resource": { "resourceType": "Encounter", "id": "encounter-1", "status": "finished", "class": { "code": "AMB" }, "subject": { "reference": "Patient/patient-1" }, "period": { "start": "2025-09-15T08:00:00+02:00", "end": "2025-09-15T09:00:00+02:00" } } },
+    { "fullUrl": "Medication/medication-1", "resource": { "resourceType": "Medication", "id": "medication-1", "code": { "text": "Lisinopril 10mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-1", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-1", "status": "active", "intent": "order", "medicationReference": { "reference": "Medication/medication-1" }, "subject": { "reference": "Patient/patient-1" }, "requester": { "reference": "Practitioner/practitioner-1" } } },
+
+    { "fullUrl": "Patient/patient-2", "resource": { "resourceType": "Patient", "id": "patient-2", "name": [{ "family": "Testpatient", "given": ["Bob"] }], "gender": "male", "birthDate": "1975-06-20" } },
+    { "fullUrl": "Practitioner/practitioner-2", "resource": { "resourceType": "Practitioner", "id": "practitioner-2", "name": [{ "family": "Jones", "given": ["Emily"] }], "qualification": [{ "code": { "text": "RN" } }] } },
+    { "fullUrl": "Organization/organization-2", "resource": { "resourceType": "Organization", "id": "organization-2", "name": "Northside Clinic" } },
+    { "fullUrl": "Observation/observation-2", "resource": { "resourceType": "Observation", "id": "observation-2", "status": "final", "code": { "text": "Heart rate" }, "subject": { "reference": "Patient/patient-2" }, "effectiveDateTime": "2025-09-14T11:10:00+02:00", "valueQuantity": { "value": 78, "unit": "beats/min" } } },
+    { "fullUrl": "Condition/condition-2", "resource": { "resourceType": "Condition", "id": "condition-2", "clinicalStatus": { "text": "active" }, "code": { "text": "Type 2 diabetes" }, "subject": { "reference": "Patient/patient-2" } } },
+    { "fullUrl": "Encounter/encounter-2", "resource": { "resourceType": "Encounter", "id": "encounter-2", "status": "in-progress", "class": { "code": "IMP" }, "subject": { "reference": "Patient/patient-2" }, "period": { "start": "2025-09-14T10:45:00+02:00" } } },
+    { "fullUrl": "Medication/medication-2", "resource": { "resourceType": "Medication", "id": "medication-2", "code": { "text": "Metformin 500mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-2", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-2", "status": "completed", "intent": "order", "medicationReference": { "reference": "Medication/medication-2" }, "subject": { "reference": "Patient/patient-2" }, "requester": { "reference": "Practitioner/practitioner-2" } } },
+
+    { "fullUrl": "Patient/patient-3", "resource": { "resourceType": "Patient", "id": "patient-3", "name": [{ "family": "Testpatient", "given": ["Carol"] }], "gender": "female", "birthDate": "1990-03-03" } },
+    { "fullUrl": "Practitioner/practitioner-3", "resource": { "resourceType": "Practitioner", "id": "practitioner-3", "name": [{ "family": "Brown", "given": ["Alan"] }], "qualification": [{ "code": { "text": "DO" } }] } },
+    { "fullUrl": "Organization/organization-3", "resource": { "resourceType": "Organization", "id": "organization-3", "name": "Eastside Hospital" } },
+    { "fullUrl": "Observation/observation-3", "resource": { "resourceType": "Observation", "id": "observation-3", "status": "final", "code": { "text": "Temperature" }, "subject": { "reference": "Patient/patient-3" }, "effectiveDateTime": "2025-09-10T15:20:00+02:00", "valueQuantity": { "value": 37.2, "unit": "C" } } },
+    { "fullUrl": "Condition/condition-3", "resource": { "resourceType": "Condition", "id": "condition-3", "clinicalStatus": { "text": "resolved" }, "code": { "text": "Upper respiratory infection" }, "subject": { "reference": "Patient/patient-3" } } },
+    { "fullUrl": "Encounter/encounter-3", "resource": { "resourceType": "Encounter", "id": "encounter-3", "status": "finished", "class": { "code": "EMER" }, "subject": { "reference": "Patient/patient-3" }, "period": { "start": "2025-09-10T14:50:00+02:00", "end": "2025-09-10T16:10:00+02:00" } } },
+    { "fullUrl": "Medication/medication-3", "resource": { "resourceType": "Medication", "id": "medication-3", "code": { "text": "Amoxicillin 500mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-3", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-3", "status": "on-hold", "intent": "order", "medicationReference": { "reference": "Medication/medication-3" }, "subject": { "reference": "Patient/patient-3" }, "requester": { "reference": "Practitioner/practitioner-3" } } },
+
+    { "fullUrl": "Patient/patient-4", "resource": { "resourceType": "Patient", "id": "patient-4", "name": [{ "family": "Testpatient", "given": ["Daniel"] }], "gender": "male", "birthDate": "1965-11-02" } },
+    { "fullUrl": "Practitioner/practitioner-4", "resource": { "resourceType": "Practitioner", "id": "practitioner-4", "name": [{ "family": "White", "given": ["Sara"] }], "qualification": [{ "code": { "text": "PA" } }] } },
+    { "fullUrl": "Organization/organization-4", "resource": { "resourceType": "Organization", "id": "organization-4", "name": "Westside Medical" } },
+    { "fullUrl": "Observation/observation-4", "resource": { "resourceType": "Observation", "id": "observation-4", "status": "final", "code": { "text": "Cholesterol" }, "subject": { "reference": "Patient/patient-4" }, "effectiveDateTime": "2025-08-20T09:00:00+02:00", "valueQuantity": { "value": 5.4, "unit": "mmol/L" } } },
+    { "fullUrl": "Condition/condition-4", "resource": { "resourceType": "Condition", "id": "condition-4", "clinicalStatus": { "text": "active" }, "code": { "text": "Hyperlipidemia" }, "subject": { "reference": "Patient/patient-4" } } },
+    { "fullUrl": "Encounter/encounter-4", "resource": { "resourceType": "Encounter", "id": "encounter-4", "status": "planned", "class": { "code": "AMB" }, "subject": { "reference": "Patient/patient-4" } } },
+    { "fullUrl": "Medication/medication-4", "resource": { "resourceType": "Medication", "id": "medication-4", "code": { "text": "Atorvastatin 20mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-4", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-4", "status": "active", "intent": "order", "medicationReference": { "reference": "Medication/medication-4" }, "subject": { "reference": "Patient/patient-4" }, "requester": { "reference": "Practitioner/practitioner-4" } } },
+
+    { "fullUrl": "Patient/patient-5", "resource": { "resourceType": "Patient", "id": "patient-5", "name": [{ "family": "Testpatient", "given": ["Eve"] }], "gender": "female", "birthDate": "2000-12-25" } },
+    { "fullUrl": "Practitioner/practitioner-5", "resource": { "resourceType": "Practitioner", "id": "practitioner-5", "name": [{ "family": "Green", "given": ["Mark"] }], "qualification": [{ "code": { "text": "MD" } }] } },
+    { "fullUrl": "Organization/organization-5", "resource": { "resourceType": "Organization", "id": "organization-5", "name": "Downtown Health" } },
+    { "fullUrl": "Observation/observation-5", "resource": { "resourceType": "Observation", "id": "observation-5", "status": "final", "code": { "text": "Respiratory rate" }, "subject": { "reference": "Patient/patient-5" }, "effectiveDateTime": "2025-07-01T07:30:00+02:00", "valueQuantity": { "value": 16, "unit": "breaths/min" } } },
+    { "fullUrl": "Condition/condition-5", "resource": { "resourceType": "Condition", "id": "condition-5", "clinicalStatus": { "text": "active" }, "code": { "text": "Asthma" }, "subject": { "reference": "Patient/patient-5" } } },
+    { "fullUrl": "Encounter/encounter-5", "resource": { "resourceType": "Encounter", "id": "encounter-5", "status": "finished", "class": { "code": "AMB" }, "subject": { "reference": "Patient/patient-5" }, "period": { "start": "2025-07-01T07:00:00+02:00", "end": "2025-07-01T07:45:00+02:00" } } },
+    { "fullUrl": "Medication/medication-5", "resource": { "resourceType": "Medication", "id": "medication-5", "code": { "text": "Salbutamol inhaler" } } },
+    { "fullUrl": "MedicationRequest/medrequest-5", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-5", "status": "active", "intent": "order", "medicationReference": { "reference": "Medication/medication-5" }, "subject": { "reference": "Patient/patient-5" }, "requester": { "reference": "Practitioner/practitioner-5" } } },
+
+    { "fullUrl": "Patient/patient-6", "resource": { "resourceType": "Patient", "id": "patient-6", "name": [{ "family": "Testpatient", "given": ["Frank"] }], "gender": "male", "birthDate": "1988-04-12" } },
+    { "fullUrl": "Practitioner/practitioner-6", "resource": { "resourceType": "Practitioner", "id": "practitioner-6", "name": [{ "family": "Taylor", "given": ["Olivia"] }], "qualification": [{ "code": { "text": "MD" } }] } },
+    { "fullUrl": "Organization/organization-6", "resource": { "resourceType": "Organization", "id": "organization-6", "name": "Suburban Clinic" } },
+    { "fullUrl": "Observation/observation-6", "resource": { "resourceType": "Observation", "id": "observation-6", "status": "final", "code": { "text": "Oxygen saturation" }, "subject": { "reference": "Patient/patient-6" }, "effectiveDateTime": "2025-06-30T18:45:00+02:00", "valueQuantity": { "value": 98, "unit": "%" } } },
+    { "fullUrl": "Condition/condition-6", "resource": { "resourceType": "Condition", "id": "condition-6", "clinicalStatus": { "text": "active" }, "code": { "text": "COPD" }, "subject": { "reference": "Patient/patient-6" } } },
+    { "fullUrl": "Encounter/encounter-6", "resource": { "resourceType": "Encounter", "id": "encounter-6", "status": "finished", "class": { "code": "IMP" }, "subject": { "reference": "Patient/patient-6" }, "period": { "start": "2025-06-30T17:30:00+02:00", "end": "2025-06-30T19:00:00+02:00" } } },
+    { "fullUrl": "Medication/medication-6", "resource": { "resourceType": "Medication", "id": "medication-6", "code": { "text": "Tiotropium inhaler" } } },
+    { "fullUrl": "MedicationRequest/medrequest-6", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-6", "status": "active", "intent": "order", "medicationReference": { "reference": "Medication/medication-6" }, "subject": { "reference": "Patient/patient-6" }, "requester": { "reference": "Practitioner/practitioner-6" } } },
+
+    { "fullUrl": "Patient/patient-7", "resource": { "resourceType": "Patient", "id": "patient-7", "name": [{ "family": "Testpatient", "given": ["Grace"] }], "gender": "female", "birthDate": "1958-09-09" } },
+    { "fullUrl": "Practitioner/practitioner-7", "resource": { "resourceType": "Practitioner", "id": "practitioner-7", "name": [{ "family": "Hall", "given": ["Victor"] }], "qualification": [{ "code": { "text": "MD" } }] } },
+    { "fullUrl": "Organization/organization-7", "resource": { "resourceType": "Organization", "id": "organization-7", "name": "Community Health" } },
+    { "fullUrl": "Observation/observation-7", "resource": { "resourceType": "Observation", "id": "observation-7", "status": "final", "code": { "text": "Weight" }, "subject": { "reference": "Patient/patient-7" }, "effectiveDateTime": "2025-05-12T10:00:00+02:00", "valueQuantity": { "value": 72.5, "unit": "kg" } } },
+    { "fullUrl": "Condition/condition-7", "resource": { "resourceType": "Condition", "id": "condition-7", "clinicalStatus": { "text": "inactive" }, "code": { "text": "Depression" }, "subject": { "reference": "Patient/patient-7" } } },
+    { "fullUrl": "Encounter/encounter-7", "resource": { "resourceType": "Encounter", "id": "encounter-7", "status": "finished", "class": { "code": "AMB" }, "subject": { "reference": "Patient/patient-7" }, "period": { "start": "2025-05-12T09:30:00+02:00", "end": "2025-05-12T10:15:00+02:00" } } },
+    { "fullUrl": "Medication/medication-7", "resource": { "resourceType": "Medication", "id": "medication-7", "code": { "text": "Sertraline 50mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-7", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-7", "status": "active", "intent": "order", "medicationReference": { "reference": "Medication/medication-7" }, "subject": { "reference": "Patient/patient-7" }, "requester": { "reference": "Practitioner/practitioner-7" } } },
+
+    { "fullUrl": "Patient/patient-8", "resource": { "resourceType": "Patient", "id": "patient-8", "name": [{ "family": "Testpatient", "given": ["Henry"] }], "gender": "male", "birthDate": "1995-02-28" } },
+    { "fullUrl": "Practitioner/practitioner-8", "resource": { "resourceType": "Practitioner", "id": "practitioner-8", "name": [{ "family": "Adams", "given": ["Nina"] }], "qualification": [{ "code": { "text": "MD" } }] } },
+    { "fullUrl": "Organization/organization-8", "resource": { "resourceType": "Organization", "id": "organization-8", "name": "Lakeside Medical" } },
+    { "fullUrl": "Observation/observation-8", "resource": { "resourceType": "Observation", "id": "observation-8", "status": "final", "code": { "text": "Glucose" }, "subject": { "reference": "Patient/patient-8" }, "effectiveDateTime": "2025-04-03T08:15:00+02:00", "valueQuantity": { "value": 6.1, "unit": "mmol/L" } } },
+    { "fullUrl": "Condition/condition-8", "resource": { "resourceType": "Condition", "id": "condition-8", "clinicalStatus": { "text": "active" }, "code": { "text": "Pre-diabetes" }, "subject": { "reference": "Patient/patient-8" } } },
+    { "fullUrl": "Encounter/encounter-8", "resource": { "resourceType": "Encounter", "id": "encounter-8", "status": "finished", "class": { "code": "AMB" }, "subject": { "reference": "Patient/patient-8" }, "period": { "start": "2025-04-03T07:50:00+02:00", "end": "2025-04-03T08:30:00+02:00" } } },
+    { "fullUrl": "Medication/medication-8", "resource": { "resourceType": "Medication", "id": "medication-8", "code": { "text": "Aspirin 75mg" } } },
+    { "fullUrl": "MedicationRequest/medrequest-8", "resource": { "resourceType": "MedicationRequest", "id": "medrequest-8", "status": "completed", "intent": "order", "medicationReference": { "reference": "Medication/medication-8" }, "subject": { "reference": "Patient/patient-8" }, "requester": { "reference": "Practitioner/practitioner-8" } } },
+
+    { "fullUrl": "Observation/observation-9", "resource": { "resourceType": "Observation", "id": "observation-9", "status": "final", "code": { "text": "ECG" }, "subject": { "reference": "Patient/patient-1" }, "effectiveDateTime": "2025-09-01T10:00:00+02:00", "component": [{ "code": { "text": "PR interval" }, "valueQuantity": { "value": 160, "unit": "ms" } }] } },
+    { "fullUrl": "Observation/observation-10", "resource": { "resourceType": "Observation", "id": "observation-10", "status": "final", "code": { "text": "Blood glucose" }, "subject": { "reference": "Patient/patient-2" }, "effectiveDateTime": "2025-09-02T09:30:00+02:00", "valueQuantity": { "value": 5.8, "unit": "mmol/L" } } },
+
+    { "fullUrl": "DiagnosticReport/diagnosticreport-1", "resource": { "resourceType": "DiagnosticReport", "id": "diagnosticreport-1", "status": "final", "code": { "text": "Basic metabolic panel" }, "subject": { "reference": "Patient/patient-2" }, "result": [{ "reference": "Observation/observation-10" }, { "reference": "Observation/observation-2" }] } },
+    { "fullUrl": "Immunization/immunization-1", "resource": { "resourceType": "Immunization", "id": "immunization-1", "status": "completed", "vaccineCode": { "text": "Influenza vaccine" }, "patient": { "reference": "Patient/patient-3" }, "occurrenceDateTime": "2024-10-01T10:00:00+02:00" } },
+    { "fullUrl": "AllergyIntolerance/allergy-1", "resource": { "resourceType": "AllergyIntolerance", "id": "allergy-1", "clinicalStatus": { "text": "active" }, "verificationStatus": { "text": "confirmed" }, "code": { "text": "Peanut allergy" }, "patient": { "reference": "Patient/patient-4" } } },
+
+    { "fullUrl": "Observation/observation-11", "resource": { "resourceType": "Observation", "id": "observation-11", "status": "final", "code": { "text": "Hemoglobin" }, "subject": { "reference": "Patient/patient-5" }, "effectiveDateTime": "2025-03-20T08:00:00+02:00", "valueQuantity": { "value": 13.1, "unit": "g/dL" } } },
+    { "fullUrl": "Condition/condition-9", "resource": { "resourceType": "Condition", "id": "condition-9", "clinicalStatus": { "text": "active" }, "code": { "text": "Anemia" }, "subject": { "reference": "Patient/patient-5" } } },
+
+    { "fullUrl": "Procedure/procedure-1", "resource": { "resourceType": "Procedure", "id": "procedure-1", "status": "completed", "code": { "text": "Appendectomy" }, "subject": { "reference": "Patient/patient-6" }, "performedDateTime": "2023-05-21T12:00:00+02:00" } },
+    { "fullUrl": "ServiceRequest/serviceRequest-1", "resource": { "resourceType": "ServiceRequest", "id": "servicerequest-1", "status": "active", "intent": "order", "code": { "text": "MRI head" }, "subject": { "reference": "Patient/patient-7" }, "requester": { "reference": "Practitioner/practitioner-7" } } },
+
+    { "fullUrl": "Coverage/coverage-1", "resource": { "resourceType": "Coverage", "id": "coverage-1", "status": "active", "beneficiary": { "reference": "Patient/patient-1" }, "payor": [{ "reference": "Organization/organization-1" }] } },
+    { "fullUrl": "Claim/claim-1", "resource": { "resourceType": "Claim", "id": "claim-1", "status": "active", "use": "claim", "patient": { "reference": "Patient/patient-1" }, "insurance": [{ "coverage": { "reference": "Coverage/coverage-1" } }], "item": [{ "sequence": 1, "productOrService": { "text": "Consultation" }, "net": { "value": 120, "currency": "EUR" } }] } },
+
+    { "fullUrl": "Invoice/invoice-1", "resource": { "resourceType": "Invoice", "id": "invoice-1", "status": "issued", "subject": { "reference": "Patient/patient-2" }, "totalGross": { "value": 240, "currency": "EUR" } } },
+    { "fullUrl": "Observation/observation-12", "resource": { "resourceType": "Observation", "id": "observation-12", "status": "final", "code": { "text": "Creatinine" }, "subject": { "reference": "Patient/patient-6" }, "effectiveDateTime": "2025-02-11T09:00:00+02:00", "valueQuantity": { "value": 88, "unit": "µmol/L" } } },
+
+    { "fullUrl": "Observation/observation-13", "resource": { "resourceType": "Observation", "id": "observation-13", "status": "final", "code": { "text": "Albumin" }, "subject": { "reference": "Patient/patient-4" }, "effectiveDateTime": "2025-01-17T08:00:00+02:00", "valueQuantity": { "value": 40, "unit": "g/L" } } },
+    { "fullUrl": "Observation/observation-14", "resource": { "resourceType": "Observation", "id": "observation-14", "status": "final", "code": { "text": "Platelets" }, "subject": { "reference": "Patient/patient-5" }, "effectiveDateTime": "2024-11-21T10:30:00+02:00", "valueQuantity": { "value": 250, "unit": "10^9/L" } } },
+
+    { "fullUrl": "PractitionerRole/practitionerrole-1", "resource": { "resourceType": "PractitionerRole", "id": "practitionerrole-1", "practitioner": { "reference": "Practitioner/practitioner-1" }, "organization": { "reference": "Organization/organization-1" }, "code": [{ "text": "Cardiologist" }] } },
+    { "fullUrl": "PractitionerRole/practitionerrole-2", "resource": { "resourceType": "PractitionerRole", "id": "practitionerrole-2", "practitioner": { "reference": "Practitioner/practitioner-2" }, "organization": { "reference": "Organization/organization-2" }, "code": [{ "text": "Nurse" }] } },
+
+    { "fullUrl": "Observation/observation-15", "resource": { "resourceType": "Observation", "id": "observation-15", "status": "amended", "code": { "text": "CRP" }, "subject": { "reference": "Patient/patient-7" }, "effectiveDateTime": "2024-10-30T11:00:00+02:00", "valueQuantity": { "value": 2.5, "unit": "mg/L" } } },
+
+    { "fullUrl": "Consent/consent-1", "resource": { "resourceType": "Consent", "id": "consent-1", "status": "active", "patient": { "reference": "Patient/patient-1" }, "scope": { "text": "treatment" } } },
+
+    { "fullUrl": "Appointment/appointment-1", "resource": { "resourceType": "Appointment", "id": "appointment-1", "status": "booked", "participant": [{ "actor": { "reference": "Patient/patient-1" } }, { "actor": { "reference": "Practitioner/practitioner-1" } }], "start": "2025-10-01T09:00:00+02:00", "end": "2025-10-01T09:30:00+02:00" } },
+
+    { "fullUrl": "Observation/observation-16", "resource": { "resourceType": "Observation", "id": "observation-16", "status": "final", "code": { "text": "LDL" }, "subject": { "reference": "Patient/patient-4" }, "effectiveDateTime": "2025-07-20T09:00:00+02:00", "valueQuantity": { "value": 3.1, "unit": "mmol/L" } } },
+
+    { "fullUrl": "Observation/observation-17", "resource": { "resourceType": "Observation", "id": "observation-17", "status": "final", "code": { "text": "Urea" }, "subject": { "reference": "Patient/patient-6" }, "effectiveDateTime": "2024-09-05T08:00:00+02:00", "valueQuantity": { "value": 5.2, "unit": "mmol/L" } } },
+
+    { "fullUrl": "Communication/communication-1", "resource": { "resourceType": "Communication", "id": "communication-1", "status": "completed", "subject": { "reference": "Patient/patient-2" }, "sent": "2025-09-01T14:00:00+02:00", "payload": [{ "contentString": "Follow-up instructions sent" }] } },
+
+    { "fullUrl": "Observation/observation-18", "resource": { "resourceType": "Observation", "id": "observation-18", "status": "final", "code": { "text": "TSH" }, "subject": { "reference": "Patient/patient-3" }, "effectiveDateTime": "2025-08-11T08:30:00+02:00", "valueQuantity": { "value": 2.1, "unit": "mIU/L" } } },
+
+    { "fullUrl": "Questionnaire/questionnaire-1", "resource": { "resourceType": "Questionnaire", "id": "questionnaire-1", "status": "active", "title": "Health survey" } },
+
+    { "fullUrl": "Observation/observation-19", "resource": { "resourceType": "Observation", "id": "observation-19", "status": "final", "code": { "text": "eGFR" }, "subject": { "reference": "Patient/patient-5" }, "effectiveDateTime": "2025-06-15T08:00:00+02:00", "valueQuantity": { "value": 75, "unit": "mL/min/1.73m2" } } },
+
+    { "fullUrl": "CarePlan/careplan-1", "resource": { "resourceType": "CarePlan", "id": "careplan-1", "status": "active", "subject": { "reference": "Patient/patient-1" }, "intent": "plan", "title": "Hypertension management" } },
+
+    { "fullUrl": "Observation/observation-20", "resource": { "resourceType": "Observation", "id": "observation-20", "status": "final", "code": { "text": "Vitamin D" }, "subject": { "reference": "Patient/patient-7" }, "effectiveDateTime": "2024-12-01T09:00:00+02:00", "valueQuantity": { "value": 55, "unit": "nmol/L" } } }
+
+  ]
+}

--- a/test/Benchmarks/ValidatorBenchmarks.cs
+++ b/test/Benchmarks/ValidatorBenchmarks.cs
@@ -7,99 +7,51 @@ using Hl7.Fhir.Serialization;
 using Hl7.Fhir.Specification;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Specification.Terminology;
-using System;
-using System.Diagnostics;
 using System.IO;
-using System.Threading.Tasks;
-using Task = System.Threading.Tasks.Task;
 
-//using Validator = Hl7.Fhir.Validation.Validator;
+namespace Firely.Sdk.Benchmarks;
 
-namespace Firely.Sdk.Benchmarks
+[CrossVersionConfiguration(typeof(ValidatorBenchmarks))]
+[PackageVersion("2.8.0-alpha-20250905.1", Constant = "VALSDK6")]
+[PackageVersion("2.7.0", Constant = "VALSDK5", Baseline = true)]
+// [PackageVersion("2.2.0")]
+// [ProjectReference]
+public class ValidatorBenchmarks
 {
-    [MemoryDiagnoser]
-    public class ValidatorBenchmarks
+    private static readonly IAsyncResourceResolver ZIPSOURCE = new CachedResolver(new StructureDefinitionCorrectionsResolver(ZipSource.CreateValidationSource()));
+    private static readonly IStructureDefinitionSummaryProvider PROVIDER = new StructureDefinitionSummaryProvider(ZIPSOURCE);
+    private static readonly string TEST_DIRECTORY = Path.GetFullPath(@"TestData");
+    private static readonly string TEST_BUNDLE_PATH = Path.Combine(Path.GetFullPath(@"TestData"), "ValidationBundle.json");
+    
+    private Validator Validator { get; set; } = null!;
+    
+#if VALSDK6
+    private PocoNode TestResource { get; set; } = null!;
+#elif VALSDK5
+    private ElementNode TestResource { get; set; } = null!;
+#endif
+    
+    [GlobalSetup]
+    public void Setup()
     {
-        private static readonly IResourceResolver ZIPSOURCE = new CachedResolver(new StructureDefinitionCorrectionsResolver(ZipSource.CreateValidationSource()));
-        private static readonly IStructureDefinitionSummaryProvider PROVIDER = new StructureDefinitionSummaryProvider(ZIPSOURCE);
-        private static readonly string TEST_DIRECTORY = Path.GetFullPath(@"TestData\DocumentComposition");
+        var testResourceData = File.ReadAllText(TEST_BUNDLE_PATH);
+        
+#if VALSDK6
+        var resource = FhirJsonDeserializer.OSTRICH.DeserializeResource(testResourceData);
+        TestResource = resource.ToPocoNode();
+#elif VALSDK5
+        var resource = FhirJsonNode.Parse(testResourceData).ToTypedElement(ModelInfo.ModelInspector);
+        TestResource = ElementNode.FromElement(resource);
+#endif
+        
+        var ts = new LocalTerminologyService(ZIPSOURCE);
 
-        public PocoNode? TestResource = null;
-        public string? InstanceTypeProfile = null;
-        public IResourceResolver? TestResolver = null;
+        Validator = new Validator(ZIPSOURCE, ts);
+    }
 
-        [GlobalSetup]
-        public void GlobalSetup()
-        {
-            //var testResourceData = File.ReadAllText(Path.Combine(TEST_DIRECTORY, "Levin.patient.xml"));
-            var testResourceData = File.ReadAllText(Path.Combine(TEST_DIRECTORY, "MainBundle.bundle.xml"));
-
-            TestResource = FhirXmlDeserializer.DEFAULT.DeserializeResource(testResourceData).ToPocoNode();
-            //InstanceTypeProfile = Hl7.Fhir.Model.ModelInfo.CanonicalUriForFhirCoreType(TestResource.InstanceType).Value!;
-            InstanceTypeProfile = "http://example.org/StructureDefinition/DocumentBundle";
-
-            var testFilesResolver = new DirectorySource(TEST_DIRECTORY);
-            TestResolver = new CachedResolver(new SnapshotSource(new CachedResolver(new MultiResolver(testFilesResolver, ZIPSOURCE))))!;
-
-            // To avoid warnings about bi-model distributions, run the (slow) first-time run here in setup
-            var cold = validateWip(TestResource!, InstanceTypeProfile!, TestResolver!);
-            Debug.Assert(cold.Success);
-
-            var oldCold = validateCurrent(TestResource!, InstanceTypeProfile!, TestResolver!);
-            Debug.Assert(oldCold.Success);
-        }
-
-        [Benchmark]
-        public void CurrentValidator()
-        {
-            _ = validateCurrent(TestResource!, InstanceTypeProfile!, TestResolver!);
-        }
-
-        [Benchmark]
-        public void WipValidator()
-        {
-            _ = validateWip(TestResource!, InstanceTypeProfile!, TestResolver!);
-        }
-
-        private static Hl7.Fhir.Model.OperationOutcome validateWip(PocoNode typedElement, string schema, IResourceResolver rr)
-        {
-            var arr = rr.AsAsync();
-            var ts = new LocalTerminologyService(arr);
-
-            var validator = new Validator(arr, ts, new TestExternalReferenceResolver(rr));
-            var result = validator.Validate(typedElement, schema);
-            return result;
-        }
-
-        private static Hl7.Fhir.Model.OperationOutcome validateCurrent(PocoNode typedElement, string profile, IResourceResolver arr)
-        {
-            // This code needs the new shims, and no longer compiles since the old validator has been removed from the SDK.
-            throw new NotImplementedException();
-
-            //var settings = new ValidationSettings
-            //{
-            //    GenerateSnapshot = true,
-            //    GenerateSnapshotSettings = SnapshotGeneratorSettings.CreateDefault(),
-            //    ResourceResolver = arr,
-            //    TerminologyService = new LocalTerminologyService(arr.AsAsync()),
-            //    ResolveExternalReferences = true
-            //};
-
-            //var validator = new Validator(settings);
-            //var outcome = profile is null ? validator.Validate(typedElement, Hl7.Fhir.Model.ModelInfo.ModelInspector) : validator.Validate(typedElement, Hl7.Fhir.Model.ModelInfo.ModelInspector, profile);
-            //return outcome;
-        }
-
-        private class TestExternalReferenceResolver : IExternalReferenceResolver
-        {
-            public TestExternalReferenceResolver(IResourceResolver resolver)
-            {
-                Resolver = resolver;
-            }
-
-            public IResourceResolver Resolver { get; }
-
-            public Task<object?> ResolveAsync(string reference) => Task.FromResult((object?)Resolver.TryResolveByUri(reference).Value);
-        }
+    [Benchmark]
+    public OperationOutcome PerformanceLargeValidation()
+    {
+        return Validator.Validate(TestResource);
     }
 }


### PR DESCRIPTION
## Description
From benchmarking the SDK5 version and SDK6 version of validator, I saw around 5-10% improvement in run-time, but more importantly 20% reduction in memory usage.

| Method                     | Job                    | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
|--------------------------- |----------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
| PerformanceLargeValidation | 2.7.0                  | 17.85 ms | 0.348 ms | 0.308 ms |  1.00 |    0.02 |  33.78 MB |        1.00 |
| PerformanceLargeValidation | 2.8.0-alpha-20250905.1 | 16.36 ms | 0.297 ms | 0.354 ms |  0.92 |    0.02 |  27.53 MB |        0.81 |

## Related issues
Closes #505 