### PR TITLE
Assertion needs to be public for MessagePack to work

### DIFF
--- a/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BaseTypeInvariantConstraintsValidator.cs
@@ -22,7 +22,7 @@ namespace Firely.Fhir.Validation;
 #else
 [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-internal class BaseTypeInvariantConstraintsValidator : IValidatable
+public class BaseTypeInvariantConstraintsValidator : IValidatable
 {
     /// <summary>
     /// Validate input against the expected context and invariants.
@@ -44,8 +44,8 @@ internal class BaseTypeInvariantConstraintsValidator : IValidatable
     }
 
     /// <summary>
-    /// 
+    /// Converts this instance to a JSON token representing the base type invariant constraints.
     /// </summary>
-    /// <returns></returns>
+    /// <return>A JToken representing the JSON structure for base type invariants.</return>
     public JToken ToJson() => new JProperty("baseTypeInvariants", new JObject());
 }

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -32,6 +32,10 @@ Firely.Fhir.Validation.BaseType
 Firely.Fhir.Validation.BaseType.BaseType(string! type) -> void
 Firely.Fhir.Validation.BaseType.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.BaseType.Type.get -> string!
+Firely.Fhir.Validation.BaseTypeInvariantConstraintsValidator
+Firely.Fhir.Validation.BaseTypeInvariantConstraintsValidator.BaseTypeInvariantConstraintsValidator() -> void
+Firely.Fhir.Validation.BaseTypeInvariantConstraintsValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
+Firely.Fhir.Validation.BaseTypeInvariantConstraintsValidator.Validate(Firely.Fhir.Validation.IScopedNode! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state) -> Firely.Fhir.Validation.ResultReport!
 Firely.Fhir.Validation.BasicValidator
 Firely.Fhir.Validation.BasicValidator.BasicValidator() -> void
 Firely.Fhir.Validation.BindingValidator


### PR DESCRIPTION
## Description
MessagePack in CAR factory needs the IAssertion implementations to be public to be serializable.
Will need to be forward merged to SDK6 as well