### PR TITLE
Enable trusted code signing

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
       certificateProfileName: 'FirelyCodeSigning'
       trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
       trustedSigningAccountName: 'FirelyCodeSigning'
-      azureServiceConnection: 'AzureTrustedSigningPrincipal'
+      azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -45,8 +45,10 @@ stages:
       testProjects: '**/*Tests*/*Tests.csproj'
       signingKeyFileName: 'FirelyValidator.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\src\Firely.Fhir.Validation*\bin\*\*\Firely.Fhir.Validation*.dll'
-      codeSignerCertificate: $(FirelyCodeSignerCertificate)
-      codeSignerPassword: $(CodeSigningPassword)
+      certificateProfileName: 'FirelyCodeSigning'
+      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+      trustedSigningAccountName: 'FirelyCodeSigning'
+      azureServiceConnection: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:


### PR DESCRIPTION
This pull request updates the code signing configuration in the Azure Pipelines YAML file to use Azure Trusted Signing instead of the previous custom certificate and password approach.

**Build pipeline configuration:**

* Switched from specifying `codeSignerCertificate` and `codeSignerPassword` to using Azure Trusted Signing settings: `certificateProfileName`, `trustedSigningAccountEndpoint`, `trustedSigningAccountName`, and `azureServiceConnection` in `build/azure-pipelines.yml`.