### PR TITLE
Fix/slice cardinality validation

### DIFF
--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -194,7 +194,7 @@ public class SchemaBuilder : ISchemaBuilder
             {
                 var childrenAssertion = createChildrenAssertion(nav, subschemas, out var valueAssertion, out var requiredAssertion);
                 if (valueAssertion is not null)
-                    schemaMembers.Add(valueAssertion);
+                    schemaMembers.Add(stripGroupLevelCardinality(valueAssertion));
                 if(requiredAssertion is not null)
                     schemaMembers.Add(requiredAssertion);
                 schemaMembers.Add(childrenAssertion);
@@ -501,4 +501,24 @@ public class SchemaBuilder : ISchemaBuilder
         return sliceAssertions.Where(sa => sa is not null)!.GroupAll();
     }
 
+    /// <summary>
+    /// Strips <see cref="CardinalityValidator"/> from the members of the primitive value pseudo-child
+    /// assertion before adding it as a direct schema member.
+    /// The primitive value element (e.g. <c>boolean.value</c>) always has exactly 0..1 occurrences
+    /// per instance. When the parent element occurs multiple times the value assertion is invoked with
+    /// the whole group, causing the <see cref="CardinalityValidator"/> to count all parent instances
+    /// instead of counting the children of a single instance — producing a false cardinality violation.
+    /// Removing the cardinality is safe: a primitive always has at most one value per instance.
+    /// </summary>
+    private static IAssertion stripGroupLevelCardinality(IAssertion valueAssertion)
+    {
+        if (valueAssertion is not ElementSchema es) return valueAssertion;
+        var membersWithoutCardinality = es.Members.Where(m => m is not CardinalityValidator).ToList();
+        return membersWithoutCardinality.Count == es.Members.Count
+            ? valueAssertion  // nothing to strip
+            : new ElementSchema(es.Id, membersWithoutCardinality);
+    }
+
+
 }
+

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -193,6 +193,9 @@ public class SchemaBuilder : ISchemaBuilder
             if (nav.HasChildren)
             {
                 var childrenAssertion = createChildrenAssertion(nav, subschemas, out var valueAssertion, out var requiredAssertion);
+                // Stripping the cardinality check from value collection members (after first adding it) because stripping does 
+                // not affect the public API. Otherwise, an additional ElementConversionMode would become necessary, which would
+                // be a category of its own
                 if (valueAssertion is not null)
                     schemaMembers.Add(stripGroupLevelCardinality(valueAssertion));
                 if(requiredAssertion is not null)

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -22,7 +22,7 @@ using static Hl7.Fhir.Model.ElementDefinition;
 namespace Firely.Fhir.Validation.Compilation;
 
 /// <summary>
-/// Converts the constraints in a <see cref="StructureDefinition"/> to an
+/// Converts the constraints in a <see cref="Hl7.Fhir.Model.StructureDefinition"/> to an
 /// <see cref="ElementSchema"/>, which can then be used for validation.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
@@ -34,7 +34,7 @@ namespace Firely.Fhir.Validation.Compilation;
 public class SchemaBuilder : ISchemaBuilder
 {
     /// <summary>
-    /// The resolver to use when the <see cref="StructureDefinition"/> under conversion
+    /// The resolver to use when the <see cref="Hl7.Fhir.Model.StructureDefinition"/> under conversion
     /// refers to other StructureDefinitions.
     /// </summary>
     public readonly IAsyncResourceResolver Source;

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -507,7 +507,7 @@ public class SchemaBuilder : ISchemaBuilder
     /// <summary>
     /// Strips <see cref="CardinalityValidator"/> from the members of the primitive value pseudo-child
     /// assertion before adding it as a direct schema member.
-    /// The primitive value element (e.g. <c>boolean.value</c>) always has exactly 0..1 occurrences
+    /// The primitive value element (e.g. <c>boolean.value</c>) has at most 1 occurrence
     /// per instance. When the parent element occurs multiple times the value assertion is invoked with
     /// the whole group, causing the <see cref="CardinalityValidator"/> to count all parent instances
     /// instead of counting the children of a single instance — producing a false cardinality violation.

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilderExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace Firely.Fhir.Validation.Compilation
     internal static class SchemaBuilderExtensions
     {
         /// <summary>
-        /// Converts a <see cref="StructureDefinition"/> to an <see cref="ElementSchema"/>.
+        /// Converts a <see cref="Hl7.Fhir.Model.StructureDefinition"/> to an <see cref="ElementSchema"/>.
         /// </summary>
         public static ElementSchema? BuildSchema(this ISchemaBuilder schemaBuilder, StructureDefinition definition)
             => BuildSchema(schemaBuilder, ElementDefinitionNavigator.ForSnapshot(definition));

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/BaseSchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/BaseSchemaBuilder.cs
@@ -29,7 +29,7 @@ namespace Firely.Fhir.Validation.Compilation
         /// Builds a schema block.
         /// </summary>
         /// <param name="def">The ElementDefinition for which a schema block needs to be constructed.</param>
-        /// <param name="structureDefinition">The <see cref="StructureDefinition"/> associated with the <see cref="ElementDefinition"/> </param>
+        /// <param name="structureDefinition">The <see cref="Hl7.Fhir.Model.StructureDefinition"/> associated with the <see cref="ElementDefinition"/> </param>
         /// <param name="isUnconstrainedElement"></param>
         /// <param name="conversionMode">The mode indicating the state we are in while constructing the schema block.</param>
         /// <returns></returns>

--- a/src/Firely.Fhir.Validation.Compilation.Shared/StructureDefinitionToElementSchemaResolver.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/StructureDefinitionToElementSchemaResolver.cs
@@ -6,7 +6,6 @@
  * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
  */
 
-using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using Hl7.Fhir.Specification.Source;
 using Hl7.Fhir.Utility;
@@ -23,7 +22,7 @@ namespace Firely.Fhir.Validation.Compilation
 
     /// <summary>
     /// This is an implementation of <see cref="IElementSchemaResolver"/> that takes a 
-    /// FHIR StructureDefintion as input and converts it so an <see cref="ElementSchema"/>.
+    /// FHIR StructureDefinition as input and converts it so an <see cref="ElementSchema"/>.
     /// </summary>
     /// <remarks>For this to work, it is assumed that the schema URI maps one-to-one to the
     /// canonical url of the StructureDefinition. This class takes an <see cref="IAsyncResourceResolver"/>

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Xhtml.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Xhtml.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#xhtml.value",
-    "cardinality": "1..1",
     "ref": "http://hl7.org/fhirpath/System.String"
   },
   "children": {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/boolean.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/boolean.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#boolean.value",
-    "cardinality": "0..1",
     "regex": "true|false",
     "ref": "http://hl7.org/fhirpath/System.Boolean"
   },

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/uri.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/uri.json
@@ -15,7 +15,6 @@
   "fhirUri": {},
   "nested": {
     "id": "#uri.value",
-    "cardinality": "0..1",
     "regex": "\\S*",
     "ref": "http://hl7.org/fhirpath/System.String"
   },

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Xhtml.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Xhtml.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#xhtml.value",
-    "cardinality": "1..1",
     "ref": "http://hl7.org/fhirpath/System.String"
   },
   "children": {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/boolean.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/boolean.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#boolean.value",
-    "cardinality": "0..1",
     "regex": "true|false",
     "ref": "http://hl7.org/fhirpath/System.Boolean"
   },

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Xhtml.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Xhtml.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#xhtml.value",
-    "cardinality": "1..1",
     "ref": "http://hl7.org/fhirpath/System.String"
   },
   "children": {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/boolean.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/boolean.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#boolean.value",
-    "cardinality": "0..1",
     "regex": "true|false",
     "ref": "http://hl7.org/fhirpath/System.Boolean"
   },

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Xhtml.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Xhtml.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#xhtml.value",
-    "cardinality": "1..1",
     "ref": "http://hl7.org/fhirpath/System.String"
   },
   "children": {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/boolean.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/boolean.json
@@ -14,7 +14,6 @@
   "FastInvariant-ele1": {},
   "nested": {
     "id": "#boolean.value",
-    "cardinality": "0..1",
     "ref": "http://hl7.org/fhirpath/System.Boolean"
   },
   "children": {

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/BasicSchemaBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/BasicSchemaBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿﻿/* 
+/* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/BasicSchemaBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/BasicSchemaBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿﻿/* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -15,6 +15,7 @@ using Hl7.Fhir.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -364,6 +365,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
                 .Should().BeEquivalentTo(new FhirString(source));
         }
 
+
         /// <summary>
         /// Regression test for https://github.com/FirelyTeam/firely-validator-api/issues/631
         /// </summary>
@@ -374,7 +376,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
                          ?? throw new InvalidOperationException("Profile not found");
 
             // ONE address (type="both") with TWO line elements — street name on line[0],
-            // house number on line[1], each carrying its ADXP extension.
+            // house number on line[1], each carrying its extension.
             // Slice cardinality max=1 is satisfied (one matching address instance).
             // address.line cardinality max=2 is satisfied (two line elements).
             // This MUST pass — the v3.1.0 bug causes it to fail.

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -14,7 +14,6 @@ using Hl7.Fhir.Support;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 using Xunit;
 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -1,4 +1,3 @@
-﻿﻿
 /* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SimpleValidationsTests.cs
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 /* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
@@ -362,6 +362,77 @@ namespace Firely.Fhir.Validation.Compilation.Tests
                 .Should().BeEquivalentTo(new Integer(column));
             oo.Issue[0].GetExtensionValue<FhirString>("http://hl7.org/fhir/StructureDefinition/operationoutcome-issue-source")
                 .Should().BeEquivalentTo(new FhirString(source));
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/FirelyTeam/firely-validator-api/issues/631
+        /// </summary>
+        [Fact]
+        public void SliceWithMaxOne_AllowsRepeatingChildElements()
+        {
+            var schema = _fixture.SchemaResolver.GetSchema(TestProfileArtifactSource.SLICEWITHREPEATINGCHILDREN)
+                         ?? throw new InvalidOperationException("Profile not found");
+
+            // ONE address (type="both") with TWO line elements — street name on line[0],
+            // house number on line[1], each carrying its ADXP extension.
+            // Slice cardinality max=1 is satisfied (one matching address instance).
+            // address.line cardinality max=2 is satisfied (two line elements).
+            // This MUST pass — the v3.1.0 bug causes it to fail.
+            var streetExt = new Extension(
+                "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                new FhirString("Example Street"));
+            var houseExt = new Extension(
+                "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                new FhirString("42"));
+
+            var streetLine = new FhirString("Example Street");
+            streetLine.Extension.Add(streetExt);
+
+            var houseLine = new FhirString("42");
+            houseLine.Extension.Add(houseExt);
+
+            var patient = new Patient
+            {
+                Address =
+                [
+                    new Address
+                    {
+                        Type = Address.AddressType.Both,
+                        LineElement = [streetLine, houseLine],
+                        City = "Testtown",
+                        PostalCode = "12345"
+                    }
+                ]
+            };
+
+            var result = schema.Validate(patient.ToPocoNode(), _fixture.NewValidationSettings());
+            result.IsSuccessful.Should().BeTrue(
+                "one matching address with two line elements is valid: " +
+                "slice max=1 limits the number of matching address instances, not the child line count");
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/FirelyTeam/firely-validator-api/issues/631
+        /// </summary>
+        [Fact]
+        public void SliceWithMaxOne_RejectsMultipleMatchingSliceInstances()
+        {
+            var schema = _fixture.SchemaResolver.GetSchema(TestProfileArtifactSource.SLICEWITHREPEATINGCHILDREN)
+                         ?? throw new InvalidOperationException("Profile not found");
+
+            // TWO addresses both with type="both" → two instances matching the StreetAddress slice → violates max=1.
+            var patient = new Patient
+            {
+                Address =
+                [
+                    new Address { Type = Address.AddressType.Both, Line = ["Example Street 1"] },
+                    new Address { Type = Address.AddressType.Both, Line = ["Other Avenue 2"] }
+                ]
+            };
+
+            var result = schema.Validate(patient.ToPocoNode(), _fixture.NewValidationSettings());
+            result.IsSuccessful.Should().BeFalse(
+                "two addresses both matching the StreetAddress slice violates the slice max=1 cardinality");
         }
     }
 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
@@ -1,4 +1,4 @@
-﻿﻿/* 
+/* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/TestProfileArtifactSource.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿﻿/* 
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
  * 
@@ -53,6 +53,15 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         
         public const string EMPTYSNAPSHOTUNKNOWNBASE = "http://validationtest.org/fhir/StructureDefinition/EmptySnapshotDueToUnknownBaseProfile";
 
+        /// <summary>
+        /// Regression test profile for a sliced element (Patient.address) where the slice has max=1 but
+        /// the sliced element's child (address.line) is allowed to repeat. This mirrors the pattern used
+        /// by profiles where address is sliced into e.g. "StreetAddress"
+        /// (max=1) but multiple address.line repetitions are valid within that one slice instance.
+        /// See: https://github.com/FirelyTeam/firely-validator-api/issues/631
+        /// </summary>
+        public const string SLICEWITHREPEATINGCHILDREN = "http://validationtest.org/fhir/StructureDefinition/SliceWithRepeatingChildrenTestcase";
+
 
         public List<StructureDefinition> TestProfiles =
         [
@@ -88,6 +97,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             buildExtensionValueChildConstraints(),
             
             buildEmptySnapshotWithUnknownBaseProfile(),
+            buildSliceWithRepeatingChildrenTestcase(),
         ];
         
         private static StructureDefinition buildExtensionValueChildConstraints()
@@ -651,6 +661,128 @@ namespace Firely.Fhir.Validation.Compilation.Tests
 #endif
             result.ContextInvariant = ["true", "false"];
                 return result;
+        }
+
+        /// <summary>
+        /// Builds a Patient profile that precisely mirrors the 
+        /// address slicing structure responsible for the regression in v3.1.0:
+        ///
+        ///   Patient.address is sliced by address.type (value discriminator, open slicing).
+        ///   Slice "StreetAddress":
+        ///     - max = 1         →  at most ONE street address per resource
+        ///     - address.type    fixed to "both"
+        ///     - address.line    max = 2  (up to two line elements: street name + house number)
+        ///     - address.line.extension  is further sliced by url discriminator into:
+        ///         "Street"            
+        ///         "HouseNumber"      
+        ///         "AddressSupplement" 
+        ///       This nested extension slicing is the key structural detail that distinguishes
+        ///       this profile from a simpler slice and is present in the real profiles.
+        ///
+        /// Regression: in v3.1.0 the validator incorrectly applied the slice-level cardinality
+        /// (0..1, from StreetAddress max=1) to the COUNT of address.line elements instead of
+        /// counting the number of address instances matching the slice.  This produced:
+        ///   "Instance count at element 'line' is 2, which is not within the specified cardinality
+        ///    of 0..1 (for slice StreetAddress)"
+        /// even though the instance had exactly ONE matching address with TWO valid line elements.
+        /// </summary>
+        private static StructureDefinition buildSliceWithRepeatingChildrenTestcase()
+        {
+            var result = createTestSD(
+                SLICEWITHREPEATINGCHILDREN,
+                "SliceWithRepeatingChildrenTestcase",
+                "Patient profile mirroring address slicing: StreetAddress slice (max=1) with address.line (max=2) and nested extension slicing on line.extension",
+                FHIRAllTypes.Patient);
+
+            var cons = result.Differential!.Element;
+
+            // ── address slicing intro ───────────────────────────────────────────────
+            // Sliced by address.type (value discriminator), open rules.
+            var slicingIntro = new ElementDefinition("Patient.address");
+            slicingIntro.WithSlicingIntro(
+                ElementDefinition.SlicingRules.Open,
+                (ElementDefinition.DiscriminatorType.Value, "type"));
+            cons.Add(slicingIntro);
+
+            // ── Slice "StreetAddress" ───────────────────
+            // max=1: at most ONE address of this type is allowed.
+            // This is the cardinality that must NOT be applied to address.line children.
+            cons.Add(new ElementDefinition("Patient.address")
+            {
+                ElementId = "Patient.address:StreetAddress",
+                SliceName = "StreetAddress",
+                Min = 0,
+                Max = "1"
+            });
+
+            // Discriminator: address.type = "both"
+            cons.Add(new ElementDefinition("Patient.address.type")
+            {
+                ElementId = "Patient.address:StreetAddress.type",
+            }.Value(new Code("both")));
+
+            // address.line: min=1, max=2 — one or two line repetitions are valid within
+            // the single StreetAddress (e.g. line[0]=street name, line[1]=house number).
+            // The bug compared count(line)=2 against the slice max=1 instead of this max=2.
+            cons.Add(new ElementDefinition("Patient.address.line")
+            {
+                ElementId = "Patient.address:StreetAddress.line",
+                Min = 1,
+                Max = "2"
+            });
+
+            // address.line.extension: sliced by url — this nesting is present in the real 
+            // profiles and is required to reproduce the bug path through the schema compiler.
+            cons.Add(new ElementDefinition("Patient.address.line.extension")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension",
+            }.WithSlicingIntro(
+                ElementDefinition.SlicingRules.Open,
+                (ElementDefinition.DiscriminatorType.Value, "url")));
+
+            // Sub-slice: Street — url fixed to the streetName extension
+            cons.Add(new ElementDefinition("Patient.address.line.extension")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:Street",
+                SliceName = "Street",
+                Min = 0,
+                Max = "1"
+            });
+            cons.Add(new ElementDefinition("Patient.address.line.extension.url")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:Street.url",
+                Fixed = new FhirUri("http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName")
+            });
+
+            // Sub-slice: HouseNumber — url fixed to the houseNumber extension
+            cons.Add(new ElementDefinition("Patient.address.line.extension")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:HouseNumber",
+                SliceName = "HouseNumber",
+                Min = 0,
+                Max = "1"
+            });
+            cons.Add(new ElementDefinition("Patient.address.line.extension.url")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:HouseNumber.url",
+                Fixed = new FhirUri("http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber")
+            });
+
+            // Sub-slice: AddressSupplement — url fixed to the additionalLocator extension
+            cons.Add(new ElementDefinition("Patient.address.line.extension")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:AddressSupplement",
+                SliceName = "AddressSupplement",
+                Min = 0,
+                Max = "1"
+            });
+            cons.Add(new ElementDefinition("Patient.address.line.extension.url")
+            {
+                ElementId = "Patient.address:StreetAddress.line.extension:AddressSupplement.url",
+                Fixed = new FhirUri("http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-additionalLocator")
+            });
+
+            return result;
         }
 
         private static StructureDefinition createTestSD(string url, string name, string description, FHIRAllTypes constrainedType, string? baseUri = null)


### PR DESCRIPTION
There was a problem with checking slices of a primitive type (string, in this case). These slices carry a cardinality for the value, which is applied to the collection because there is no hierarchical difference between collection and value. The solution is to actively remove the cardinality check for value. That is not a problem, since it is already 1..1 bound to the item