### PR TITLE
Fix benchmark projects failing at runtime

### DIFF
--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -29,18 +29,19 @@
         <ProjectReference Include="..\..\src\Firely.Fhir.Validation.R4\Firely.Fhir.Validation.R4.csproj" />
     </ItemGroup>
     
-    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK5'))">
+    <PropertyGroup Condition="$(DefineConstants.Contains('VALSDK5'))">
         <ValidatorVersion Condition="'$(ValidatorVersion)' == ''">2.7.0</ValidatorVersion>
         <SDKVersion Condition="'$(SDKVersion)' == ''">5.12.1</SDKVersion>
-        <PackageReference Include="Firely.Fhir.Validation.R4" Version="$(ValidatorVersion)" />
-        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="$(SDKVersion)" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK6'))">        
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(DefineConstants.Contains('VALSDK6'))">
         <ValidatorVersion Condition="'$(ValidatorVersion)' == ''">2.8.0-alpha-20250905.1</ValidatorVersion>
         <SDKVersion Condition="'$(SDKVersion)' == ''">6.0.0-rc2-20250915.4</SDKVersion>
-        <PackageReference Include="Firely.Fhir.Validation.R4" Version="$(ValidatorVersion)" />
-        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="$(SDKVersion)" />
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Condition="'$(ValidatorVersion)' != ''" Include="Firely.Fhir.Validation.R4" Version="$(ValidatorVersion)" />
+        <PackageReference Condition="'$(SDKVersion)' != ''" Include="Hl7.Fhir.Specification.Data.R4" Version="$(SDKVersion)" />
     </ItemGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/test/Benchmarks/Benchmarks.csproj
+++ b/test/Benchmarks/Benchmarks.csproj
@@ -30,13 +30,17 @@
     </ItemGroup>
     
     <ItemGroup Condition="$(DefineConstants.Contains('VALSDK5'))">
-        <PackageReference Include="Firely.Fhir.Validation.R4" Version="2.7.0" />
-        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="5.12.1" />
+        <ValidatorVersion Condition="'$(ValidatorVersion)' == ''">2.7.0</ValidatorVersion>
+        <SDKVersion Condition="'$(SDKVersion)' == ''">5.12.1</SDKVersion>
+        <PackageReference Include="Firely.Fhir.Validation.R4" Version="$(ValidatorVersion)" />
+        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="$(SDKVersion)" />
     </ItemGroup>
     
-    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK6'))">
-        <PackageReference Include="Firely.Fhir.Validation.R4" Version="2.8.0-alpha-20250905.1" />
-        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="6.0.0-rc2-20250915.4" />
+    <ItemGroup Condition="$(DefineConstants.Contains('VALSDK6'))">        
+        <ValidatorVersion Condition="'$(ValidatorVersion)' == ''">2.8.0-alpha-20250905.1</ValidatorVersion>
+        <SDKVersion Condition="'$(SDKVersion)' == ''">6.0.0-rc2-20250915.4</SDKVersion>
+        <PackageReference Include="Firely.Fhir.Validation.R4" Version="$(ValidatorVersion)" />
+        <PackageReference Include="Hl7.Fhir.Specification.Data.R4" Version="$(SDKVersion)" />
     </ItemGroup>
 
 	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
+++ b/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
 {
-    private record PackageVersion(string Version, string? Constant = null, bool Baseline = false);
+    private record PackageVersion(string ValidatorVersion, string SDKVersion, string? Constant = null, bool Baseline = false);
     private readonly static string[] ALL_VERSIONS = [
         "2.7.0",
         "2.8.0-alpha-20250905.1"
@@ -35,15 +35,15 @@ public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
 
     private static IEnumerable<Job> buildJobsFromVersions(IEnumerable<PackageVersion> versions)
     {
-        foreach (var major in versions.ToLookup(x => x.Version[0]+x.Version[2]))
+        foreach (var major in versions.ToLookup(x => x.SDKVersion[0]))
         {
             foreach (var version in major)
             {
-                var defConst = version.Constant ?? $"VAL{major.Key}";
+                var defConst = version.Constant ?? $"VALSDK{major.Key}";
                 var job = Job.Default
-                    .WithId(version.Version)
+                    .WithId(version.ValidatorVersion)
                     // will upgrade the version defined in csproj to a specified version
-                    .WithMsBuildArguments($"/p:{PACKAGE}={version}", getArgFor(defConst));
+                    .WithMsBuildArguments($"/p:ValidatorVersion={version.ValidatorVersion}", $"/p:SDKVersion={version.SDKVersion}", getArgFor(defConst));
 
                 if (version.Baseline)
                     yield return job.AsBaseline();
@@ -63,9 +63,9 @@ public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
 }
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-public class PackageVersionAttribute(string PackageVersion) : Attribute
+public class PackageVersionAttribute(string ValidatorVersion) : Attribute
 {
-    public string PackageVersion { get; } = PackageVersion;
+    public string PackageVersion { get; } = ValidatorVersion;
     public string? Constant { get; set; } = null;
     public bool Baseline { get; set; } = false;
 }

--- a/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
+++ b/test/Benchmarks/Configuration/CrossVersionConfiguration.cs
@@ -9,9 +9,9 @@ using System.Reflection;
 public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
 {
     private record PackageVersion(string ValidatorVersion, string SDKVersion, string? Constant = null, bool Baseline = false);
-    private readonly static string[] ALL_VERSIONS = [
-        "2.7.0",
-        "2.8.0-alpha-20250905.1"
+    private readonly static PackageVersion[] ALL_VERSIONS = [
+        new("2.7.0",                    "5.12.1"),
+        new("2.8.0-alpha-20250905.1",   "6.0.0-rc2-20250915.4")
     ];
 
     private const string PACKAGE = "Firely.Fhir.Validation.R4";
@@ -19,10 +19,10 @@ public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
     public CrossVersionConfigurationAttribute(Type benchmarkType, bool displayGenColumns = false)
     {
         var attributes = benchmarkType.GetCustomAttributes(typeof(PackageVersionAttribute), false);
-        var versions = attributes.OfType<PackageVersionAttribute>().Select(x=> new PackageVersion(x.PackageVersion, x.Constant, x.Baseline)).Distinct().ToList();
+        var versions = attributes.OfType<PackageVersionAttribute>().Select(x => new PackageVersion(x.ValidatorVersion, x.SDKVersion, x.Constant, x.Baseline)).Distinct().ToList();
         
         if (versions.Count == 0)
-            versions.AddRange(ALL_VERSIONS.Select(x => new PackageVersion(x)));
+            versions.AddRange(ALL_VERSIONS);
         
         Config = ManualConfig.CreateEmpty()
             .AddDiagnoser(new MemoryDiagnoser(new(displayGenColumns)))
@@ -63,9 +63,10 @@ public class CrossVersionConfigurationAttribute : Attribute, IConfigSource
 }
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-public class PackageVersionAttribute(string ValidatorVersion) : Attribute
+public class PackageVersionAttribute(string ValidatorVersion, string SDKVersion) : Attribute
 {
-    public string PackageVersion { get; } = ValidatorVersion;
+    public string ValidatorVersion { get; } = ValidatorVersion;
+    public string SDKVersion { get; } = SDKVersion;
     public string? Constant { get; set; } = null;
     public bool Baseline { get; set; } = false;
 }

--- a/test/Benchmarks/ValidatorBenchmarks.cs
+++ b/test/Benchmarks/ValidatorBenchmarks.cs
@@ -12,8 +12,8 @@ using System.IO;
 namespace Firely.Sdk.Benchmarks;
 
 [CrossVersionConfiguration(typeof(ValidatorBenchmarks))]
-[PackageVersion("2.8.0-alpha-20250905.1", Constant = "VALSDK6")]
-[PackageVersion("2.7.0", Constant = "VALSDK5", Baseline = true)]
+[PackageVersion("2.8.0-alpha-20250905.1", "6.0.0-rc2-20250915.4", Constant = "VALSDK6")]
+[PackageVersion("2.7.0", "5.12.1", Constant = "VALSDK5", Baseline = true)]
 // [PackageVersion("2.2.0")]
 // [ProjectReference]
 public class ValidatorBenchmarks


### PR DESCRIPTION
This pull request refactors how package versions are handled in benchmark configuration, moving from single-version to dual-version (Validator and SDK) support. The changes improve flexibility and clarity by explicitly specifying both `ValidatorVersion` and `SDKVersion` for each benchmark run, and updating the project file to use these properties for package references.

**Benchmark configuration improvements:**

* Changed `PackageVersion` and `PackageVersionAttribute` to include both `ValidatorVersion` and `SDKVersion`, allowing benchmarks to target specific combinations of validator and SDK versions. [[1]](diffhunk://#diff-ccdc78d6726d11487db78d2a21ff2bc9e8512b20ecd99bd4855467a72f01035cL11-R25) [[2]](diffhunk://#diff-ccdc78d6726d11487db78d2a21ff2bc9e8512b20ecd99bd4855467a72f01035cL66-R69)
* Updated the logic in `CrossVersionConfigurationAttribute` to use the new dual-version structure, ensuring correct version selection and job creation for benchmarks. [[1]](diffhunk://#diff-ccdc78d6726d11487db78d2a21ff2bc9e8512b20ecd99bd4855467a72f01035cL11-R25) [[2]](diffhunk://#diff-ccdc78d6726d11487db78d2a21ff2bc9e8512b20ecd99bd4855467a72f01035cL38-R46)

**Project file changes for version flexibility:**

* Refactored `Benchmarks.csproj` to use `ValidatorVersion` and `SDKVersion` properties for package references, enabling dynamic selection of package versions based on defined constants.

**Benchmark annotation updates:**

* Updated `ValidatorBenchmarks` to use the new `PackageVersionAttribute` format, specifying both validator and SDK versions for each benchmark case.