### PR TITLE
Replace certificate signing with Azure Trusted Signing for tags

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -44,8 +44,11 @@ stages:
       testProjects: '**/*Tests*/*Tests.csproj'
       signingKeyFileName: 'FirelyValidator.snk' 
       filesForSigning: '$(Build.SourcesDirectory)\src\Firely.Fhir.Validation*\bin\*\*\Firely.Fhir.Validation*.dll'
-      codeSignerCertificate: $(FirelyCodeSignerCertificate)
-      codeSignerPassword: $(CodeSigningPassword)
+      ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+        certificateProfileName: 'FirelyCodeSigning'
+        trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+        trustedSigningAccountName: 'FirelyCodeSigning'
+        azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       pool: 
         vmImage: $(vmImage)
       preBuildSteps:


### PR DESCRIPTION
This pull request updates the code signing configuration in the Azure Pipelines YAML file. The main change is a switch to a more secure and centralized code signing process that is only triggered for builds from version tags.

**Pipeline configuration improvements:**

* Updated the code signing step to use Azure Trusted Signing with a certificate profile and service connection, instead of direct certificate and password variables. This new configuration is conditionally applied only when building from version tags, improving both security and maintainability.
