### PR TITLE
Start development phase 3.2.1

### DIFF
--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -2,7 +2,7 @@
 
     <!-- Solution-wide properties for NuGet packaging -->
     <PropertyGroup>
-        <VersionPrefix>3.1.0</VersionPrefix>
+        <VersionPrefix>3.2.1</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <Authors>Firely</Authors>
         <Company>Firely (https://fire.ly)</Company>


### PR DESCRIPTION
## Summary
- Bumps `VersionPrefix` to 3.2.1 to start the next development phase after the v3.2.0 release.

## Test plan
- [ ] CI build passes.