### PR TITLE
Start development phase 3.2.1

### DIFF
--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -8,12 +8,12 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <FirelySdkVersion>6.0.2</FirelySdkVersion>
+        <FirelySdkVersion>6.1.1</FirelySdkVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="FluentAssertions" Version="7.2.1" />
+        <PackageReference Include="FluentAssertions" Version="7.2.2" />
         <PackageReference Include="MessagePack" Version="3.1.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
@@ -23,11 +23,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Firely.Fhir.Packages" Version="5.0.1" />
+        <PackageReference Include="Firely.Fhir.Packages" Version="5.0.2" />
     </ItemGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/firely-validator-api-tests.props
+++ b/firely-validator-api-tests.props
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <FirelySdkVersion>6.1.1</FirelySdkVersion>
+        <FirelySdkVersion>6.2.0</FirelySdkVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -2,7 +2,7 @@
 
     <!-- Solution-wide properties for NuGet packaging -->
     <PropertyGroup>
-        <VersionPrefix>3.1.0</VersionPrefix>
+        <VersionPrefix>3.2.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <Authors>Firely</Authors>
         <Company>Firely (https://fire.ly)</Company>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -29,7 +29,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <FirelySdkVersion>6.1.1</FirelySdkVersion>
+        <FirelySdkVersion>6.2.0</FirelySdkVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -2,7 +2,7 @@
 
     <!-- Solution-wide properties for NuGet packaging -->
     <PropertyGroup>
-        <VersionPrefix>3.2.0</VersionPrefix>
+        <VersionPrefix>3.2.1</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <Authors>Firely</Authors>
         <Company>Firely (https://fire.ly)</Company>

--- a/firely-validator-api.props
+++ b/firely-validator-api.props
@@ -29,7 +29,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <FirelySdkVersion>6.0.2</FirelySdkVersion>
+        <FirelySdkVersion>6.1.1</FirelySdkVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -252,7 +252,7 @@ namespace Firely.Fhir.Validation
         {
             try
             {
-                var callParams = parameters.Build();
+                var callParams = (Parameters)parameters.DeepCopy();
                 return interpretResults(TaskHelper.Await(() => ctx.ValidateCodeService.ValueSetValidateCode(callParams)), display);
             }
             catch (FhirOperationException tse)


### PR DESCRIPTION
## Summary
- Forward-merges the `release/3.2.0` branch back into `develop` to start the 3.2.1 development phase.
- Brings in the Firely SDK 6.2.0 bump and corresponding `fhir-test-cases` submodule pointer update made on the release branch.

## Test plan
- [ ] CI build passes.