### PR TITLE
Skip format checks for primitives without a value

### DIFF
--- a/src/Firely.Fhir.Validation/Impl/CanonicalValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/CanonicalValidator.cs
@@ -36,7 +36,9 @@ namespace Firely.Fhir.Validation
         ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
         {
             if (input is PrimitiveNode { Primitive: Hl7.Fhir.Model.Canonical canonical })
-                return canonical.HasAnchor || canonical.IsAbsolute
+                // An absent value (e.g. a primitive carrying only a data-absent-reason extension)
+                // is not subject to the format check.
+                return canonical.Value is null || canonical.HasAnchor || canonical.IsAbsolute
                     ? ResultReport.SUCCESS
                     : new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE,
                         $"Canonical URLs must be absolute URLs if they are not fragment references").AsResult(state, input, nameof(CanonicalValidator), this);

--- a/src/Firely.Fhir.Validation/Impl/FhirUriValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirUriValidator.cs
@@ -19,10 +19,13 @@ namespace Firely.Fhir.Validation;
 #endif
 public class FhirUriValidator : BasicValidator
 {
-    internal override ResultReport BasicValidate(PocoNode input, ValidationSettings vc, ValidationState state) => 
-        (input is PrimitiveNode {Poco: FhirUri uri}) 
-            ? uri.HasValidValue() && !string.IsNullOrWhiteSpace(uri.Value) ? ResultReport.SUCCESS : new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, $"Value '{uri}' is not a valid URI").AsResult(state, input, nameof(FhirUriValidator), this)
-            : ResultReport.SUCCESS; // TODO remove this check when the SDK is updated
+    internal override ResultReport BasicValidate(PocoNode input, ValidationSettings vc, ValidationState state) =>
+        (input is PrimitiveNode {Poco: FhirUri uri})
+            // An absent value (e.g. a primitive carrying only a data-absent-reason extension) is not
+            // subject to the format check; HasValidValue() rejects present-but-invalid values,
+            // including empty and whitespace-only strings.
+            ? uri.HasValidValue() ? ResultReport.SUCCESS : new IssueAssertion(Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, $"Value '{uri}' is not a valid URI").AsResult(state, input, nameof(FhirUriValidator), this)
+            : ResultReport.SUCCESS;
 
     /// <inheritdoc />
     protected override string Key => "fhirUri";

--- a/test/Firely.Fhir.Validation.Tests/Impl/CanonicalValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/CanonicalValidatorTests.cs
@@ -70,6 +70,12 @@ namespace Firely.Fhir.Validation.Impl.Tests
                 PocoNode.ForPrimitive(absentCanonical),
                 true, null, "an absent value must skip the format check"
             };
+            yield return new object?[]
+            {
+                new CanonicalValidator(),
+                PocoNode.ForPrimitive<Hl7.Fhir.Model.Canonical>(""),
+                false, Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, "a present but empty canonical is invalid"
+            };
         }
     }
 }

--- a/test/Firely.Fhir.Validation.Tests/Impl/CanonicalValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/CanonicalValidatorTests.cs
@@ -62,6 +62,14 @@ namespace Firely.Fhir.Validation.Impl.Tests
                 PocoNode.ForPrimitive<Hl7.Fhir.Model.Canonical>("/relative/canonical#12"),
                 true, null, "Fragments are allowed"
             };
+            var absentCanonical = new Hl7.Fhir.Model.Canonical();
+            absentCanonical.SetExtension("http://hl7.org/fhir/StructureDefinition/data-absent-reason", new Code("unknown"));
+            yield return new object?[]
+            {
+                new CanonicalValidator(),
+                PocoNode.ForPrimitive(absentCanonical),
+                true, null, "an absent value must skip the format check"
+            };
         }
     }
 }

--- a/test/Firely.Fhir.Validation.Tests/Impl/FhirUriValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/FhirUriValidatorTests.cs
@@ -31,5 +31,20 @@ namespace Firely.Fhir.Validation.Tests
             base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive<FhirUri>("urn:oid:4.4.5"), false, Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, "result must be false");
             base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive<FhirUri>("urn:uuid:f3b2bd36-199b-4591-b4db-f49db0912b64"), true, null, "result must be true");
         }
+
+        [TestMethod]
+        public void TestFhirUriValidationWithAbsentValue()
+        {
+            var validator = new FhirUriValidator();
+
+            // A primitive without a value but with an extension (e.g. data-absent-reason)
+            // must not be checked against the uri format rules - ele-1 guards truly empty elements.
+            var uri = new FhirUri();
+            uri.SetExtension("http://hl7.org/fhir/StructureDefinition/data-absent-reason", new Code("unknown"));
+            base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive(uri), true, null, "an absent value must skip the format check");
+
+            // A value that is present but empty is still invalid.
+            base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive<FhirUri>(""), false, Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, "empty URIs are invalid");
+        }
     }
 }

--- a/test/Firely.Fhir.Validation.Tests/Impl/FhirUriValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/FhirUriValidatorTests.cs
@@ -43,8 +43,9 @@ namespace Firely.Fhir.Validation.Tests
             uri.SetExtension("http://hl7.org/fhir/StructureDefinition/data-absent-reason", new Code("unknown"));
             base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive(uri), true, null, "an absent value must skip the format check");
 
-            // A value that is present but empty is still invalid.
+            // A value that is present but empty or whitespace-only is still invalid.
             base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive<FhirUri>(""), false, Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, "empty URIs are invalid");
+            base.BasicValidatorTestcases(validator, PocoNode.ForPrimitive<FhirUri>(" "), false, Issue.CONTENT_ELEMENT_INVALID_PRIMITIVE_VALUE, "whitespace-only URIs are invalid");
         }
     }
 }


### PR DESCRIPTION
## Description
Since the SDK6 upgrade, `FhirUriValidator` rejects FHIR primitives that have no value at all — e.g. elements carrying only a `data-absent-reason` extension — reporting `Value '' is not a valid URI` (for instance on `Patient.identifier[0].system` when only `_system` is present). The `!string.IsNullOrWhiteSpace(uri.Value)` guard added in 37ea4c6 (to make empty URIs invalid) also catches *absent* (null) values, whereas the pre-SDK6 (v2.x) validator explicitly returned success for null.

`FhirUri.IsValidValue` in the SDK now rejects empty/whitespace strings itself (the clause even carried a `// TODO remove this check when the SDK is updated` comment), so `HasValidValue()` alone keeps empty URIs invalid while letting absent values skip the format check, as before.

`CanonicalValidator` had the same defect class — a canonical without a value failed the "must be absolute" check — and now also skips the check when the value is absent.

## Related issues
Closes #677

## Testing
- Added `FhirUriValidatorTests.TestFhirUriValidationWithAbsentValue`: a `FhirUri` with only a data-absent-reason extension must pass, while present-but-empty (`""`) and whitespace-only (`" "`) values must still be rejected.
- Added `CanonicalValidatorTests` cases: a `Canonical` with only a data-absent-reason extension must pass; a present-but-empty canonical (`""`) must still be rejected.
- Full `Firely.Fhir.Validation.Tests` suite passes (249/249). Also verified end-to-end: validating the Patient instance from #677 against the core Patient profile fails with `Value '' is not a valid URI` before this change and succeeds after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuhBxMpoyvFfV7Dc9bbbWz