### PR TITLE
VONK-10051: Add logical model support to the schema compiler and related validation rules

### DIFF
--- a/src/Firely.Fhir.Validation.Compilation.Shared/CommonTypeRefComponentExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/CommonTypeRefComponentExtensions.cs
@@ -73,6 +73,13 @@ namespace Firely.Fhir.Validation.Compilation
             if (elemType.Profile.Any()) return elemType.Profile;
 
             var type = elemType.GetCodeFromTypeRef();
+
+            // Logical models (e.g. CDS Hooks / Da Vinci CRD) use absolute canonical urls as the type
+            // code itself (e.g. http://hl7.org/fhir/tools/StructureDefinition/CDSHooksExtensions),
+            // rather than a bare FHIR type name - use it directly instead of wrapping it as if it
+            // were a core type name.
+            if (type.Contains("://")) return new[] { type };
+
             return new[] { Canonical.ForCoreType(type).Original };
         }
     }

--- a/src/Firely.Fhir.Validation.Compilation.Shared/Firely.Fhir.Validation.Compilation.Shared.projitems
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/Firely.Fhir.Validation.Compilation.Shared.projitems
@@ -44,6 +44,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\StandardBuilders.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\CanonicalBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\MaxLengthBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\IdExpectationBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\ImpliedStringPrefixBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\JsonNullableBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\FhirStringBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\TypeReferenceBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonTypeRefComponent.cs" />
@@ -56,5 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)StructureDefinitionCorrectionsResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StructureDefinitionToElementSchemaResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SubschemaCollector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ToolsExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\TypeSpecifierBuilder.cs" />
   </ItemGroup>
 </Project>

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -220,7 +220,14 @@ public class SchemaBuilder : ISchemaBuilder
                         ?? throw new IncorrectElementDefinitionException($"Element '{nav.Current.ElementId ?? nav.Current.Path}' carries a json-property-key " +
                             $"extension (key: '{keyChildName}') but does not have exactly one other child to use as the map entry value.");
 
-                    schemaMembers.Add(new KeyedObjectValidator(entrySchema));
+                    // The element's own CardinalityValidator would count the single JSON object
+                    // container (always exactly 1) instead of its map entries, so move the declared
+                    // cardinality onto the entries of the KeyedObjectValidator.
+                    var cardinality = schemaMembers.OfType<CardinalityValidator>().SingleOrDefault();
+                    if (cardinality is not null)
+                        schemaMembers.Remove(cardinality);
+
+                    schemaMembers.Add(new KeyedObjectValidator(entrySchema, cardinality?.Min, cardinality?.Max));
                 }
                 else
                 {

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -1,7 +1,7 @@
-﻿/* 
+/*
  * Copyright (c) 2024, Firely (info@fire.ly) and contributors
  * See the file CONTRIBUTORS for details.
- * 
+ *
  * This file is licensed under the BSD 3-Clause license
  * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
  */
@@ -66,7 +66,7 @@ public class SchemaBuilder : ISchemaBuilder
             }
 
             var subschemaCollector = new SubschemaCollector(nav);
-                
+
             var converted = ConvertElement(nav, subschemaCollector);
 
             if (subschemaCollector.FoundSubschemas)
@@ -94,8 +94,11 @@ public class SchemaBuilder : ISchemaBuilder
             sd.Abstract ?? throw new ArgumentException(nameof(sd.Abstract)),
             imposeProfiles.Any() ? imposeProfiles.ToArray() : null);
 
-        // Add "fhir type label"
-        if (sd.Abstract == false)
+        // Add "fhir type label". Not for logical models: sd.Type there is a canonical url (not a FHIR
+        // type name), so it can never match an instance's runtime type name - and since the type label
+        // is a shortcut member of ElementSchema, a spurious mismatch would silently disable all other
+        // validation for the element instead of producing a sensible error.
+        if (sd.Abstract == false && sd.Kind != StructureDefinition.StructureDefinitionKind.Logical)
             members.Insert(0, new FhirTypeLabelValidator(sd.Type));
 
         return sd.Kind switch
@@ -104,15 +107,17 @@ public class SchemaBuilder : ISchemaBuilder
             StructureDefinition.StructureDefinitionKind.ComplexType when sd.Type == "Extension" => new ExtensionSchema(sdi, members),
             StructureDefinition.StructureDefinitionKind.PrimitiveType or
                 StructureDefinition.StructureDefinitionKind.ComplexType => new DatatypeSchema(sdi, members),
+            StructureDefinition.StructureDefinitionKind.Logical => new LogicalModelSchema(sdi, members),
             _ => throw new NotSupportedException($"Compiler cannot handle SD {sd.Url}, which is of kind {sd.Kind}.")
         };
     }
 
     private List<Canonical> getBaseProfiles(StructureDefinition sd)
     {
-        return getBaseProfiles(new(), sd, Source);
+        var isLogical = sd.Kind == StructureDefinition.StructureDefinitionKind.Logical;
+        return getBaseProfiles(new(), sd, Source, isLogical);
 
-        static List<Canonical> getBaseProfiles(List<Canonical> result, StructureDefinition sd, IAsyncResourceResolver resolver)
+        static List<Canonical> getBaseProfiles(List<Canonical> result, StructureDefinition sd, IAsyncResourceResolver resolver, bool isLogical)
         {
             var myBase = sd.BaseDefinition;
             if (myBase is null) return result;
@@ -121,9 +126,14 @@ public class SchemaBuilder : ISchemaBuilder
 
             var baseSd = TaskHelper.Await(() => resolver.FindStructureDefinitionAsync(myBase));
 
-            return baseSd is not null
-                ? getBaseProfiles(result, baseSd, resolver)
-                : throw new InvalidOperationException($"StructureDefinition '{sd.Url}' mentions profile '{myBase}' as its base, but it cannot be resolved and is thus not available to the compiler.");
+            if (baseSd is not null) return getBaseProfiles(result, baseSd, resolver, isLogical);
+
+            // Logical models commonly base on http://hl7.org/fhir/StructureDefinition/Base, which is
+            // not a resolvable SD in every FHIR release. Treat an unresolvable base as chain-terminal
+            // for logical models instead of failing compilation outright.
+            if (isLogical) return result;
+
+            throw new InvalidOperationException($"StructureDefinition '{sd.Url}' mentions profile '{myBase}' as its base, but it cannot be resolved and is thus not available to the compiler.");
         }
     }
 
@@ -131,7 +141,7 @@ public class SchemaBuilder : ISchemaBuilder
     {
         const string imposeProfileUrl = "http://hl7.org/fhir/StructureDefinition/structuredefinition-imposeProfile";
         var result = new List<Canonical>();
-        
+
         if (sd.Extension is null) return result;
 
         foreach (var extension in sd.Extension.Where(e => e.Url == imposeProfileUrl))
@@ -192,26 +202,61 @@ public class SchemaBuilder : ISchemaBuilder
             // depend on the current ElementNode, but on its descendants in the ElementDefNavigator.
             if (nav.HasChildren)
             {
-                var childrenAssertion = createChildrenAssertion(nav, subschemas, out var valueAssertion, out var requiredAssertion);
-                // Stripping the cardinality check from value collection members (after first adding it) because stripping does 
-                // not affect the public API. Otherwise, an additional ElementConversionMode would become necessary, which would
-                // be a category of its own
-                if (valueAssertion is not null)
-                    schemaMembers.Add(stripGroupLevelCardinality(valueAssertion));
-                if(requiredAssertion is not null)
-                    schemaMembers.Add(requiredAssertion);
-                schemaMembers.Add(childrenAssertion);
-                    
-                // This is a temporary hack for the issue where snapshot generator won't copy the invariants from base when pulling all children into the ElementDefinitionNavigator.
-                // Extra details in this issue https://github.com/FirelyTeam/firely-validator-api/issues/491#issuecomment-2897145768
-                // Should be cleaned up once https://github.com/FirelyTeam/firely-net-sdk/issues/3156 is solved
-                // Type we're working with was pulled into definition, and we're not in a slice
-                // so we need to validate any invariant rules we might find as well, but we shouldn't pull them twice.
-                // We can skip backbone elements though, as there's nothing to copy.
-                if (schemaMembers.OfType<BaseType>().Any() && !schemaMembers.OfType<FhirPathValidator>().Any()
-                                                           && string.IsNullOrEmpty(nav.Current.SliceName) && !nav.Current.IsBackboneElement()) 
+                var childrenAssertion = createChildrenAssertion(nav, subschemas, out var valueAssertion, out var requiredAssertion, out var hasNamedElementsChild);
+
+                // A repeating logical-model element rendered as a JSON object keyed by a sibling
+                // child's value (json-property-key), instead of a JSON array - e.g. CDS Hooks'
+                // "prefetch" (keyed by "key") or CRD's flat "davinci-crd.configuration" map (keyed
+                // by "code"). The key child itself no longer appears in the wire format - its value
+                // becomes the JSON property name instead - so we replace the normal children
+                // representation with a KeyedObjectValidator over just the remaining ("value") child.
+                if (nav.StructureDefinition.Kind == StructureDefinition.StructureDefinitionKind.Logical &&
+                    nav.Current.GetJsonPropertyKey() is string keyChildName)
                 {
-                    schemaMembers.Add(new BaseTypeInvariantConstraintsValidator());
+                    var entrySchema = childrenAssertion.ChildList
+                        .Where(kvp => kvp.Key != keyChildName)
+                        .Select(kvp => kvp.Value)
+                        .SingleOrDefault()
+                        ?? throw new IncorrectElementDefinitionException($"Element '{nav.Current.ElementId ?? nav.Current.Path}' carries a json-property-key " +
+                            $"extension (key: '{keyChildName}') but does not have exactly one other child to use as the map entry value.");
+
+                    schemaMembers.Add(new KeyedObjectValidator(entrySchema));
+                }
+                else
+                {
+                    // Stripping the cardinality check from value collection members (after first adding it) because stripping does
+                    // not affect the public API. Otherwise, an additional ElementConversionMode would become necessary, which would
+                    // be a category of its own
+                    if (valueAssertion is not null)
+                        schemaMembers.Add(stripGroupLevelCardinality(valueAssertion));
+                    if (requiredAssertion is not null)
+                        schemaMembers.Add(requiredAssertion);
+                    schemaMembers.Add(childrenAssertion);
+
+                    // One of this element's own children is a named-elements extension carrier (e.g.
+                    // fhirAuthorization.extension typed CDSHooksExtensions) - its named extensions
+                    // (davinci-crd.version, etc.) are rendered directly on THIS element, not nested
+                    // under a literal "extension" key, so createChildrenAssertion already folded
+                    // AllowAdditionalChildren=true into childrenAssertion above and omitted "extension"
+                    // from its ChildList. NamedExtensionsValidator resolves each of those unforeseen
+                    // names to its defining StructureDefinition via the runtime-supplied
+                    // ValidationSettings.ConformanceResourceResolver and validates the value against
+                    // it - anything declared in childrenAssertion.ChildList is a regular (known)
+                    // child, not a named extension.
+                    if (hasNamedElementsChild)
+                        schemaMembers.Add(new NamedExtensionsValidator(childrenAssertion.ChildList.Keys));
+
+                    // This is a temporary hack for the issue where snapshot generator won't copy the invariants from base when pulling all children into the ElementDefinitionNavigator.
+                    // Extra details in this issue https://github.com/FirelyTeam/firely-validator-api/issues/491#issuecomment-2897145768
+                    // Should be cleaned up once https://github.com/FirelyTeam/firely-net-sdk/issues/3156 is solved
+                    // Type we're working with was pulled into definition, and we're not in a slice
+                    // so we need to validate any invariant rules we might find as well, but we shouldn't pull them twice.
+                    // We can skip backbone elements though, as there's nothing to copy.
+                    if (schemaMembers.OfType<BaseType>().Any() && !schemaMembers.OfType<FhirPathValidator>().Any()
+                                                               && string.IsNullOrEmpty(nav.Current.SliceName) && !nav.Current.IsBackboneElement())
+                    {
+                        schemaMembers.Add(new BaseTypeInvariantConstraintsValidator());
+                    }
                 }
             }
 
@@ -261,7 +306,7 @@ public class SchemaBuilder : ISchemaBuilder
     }
 
     //// This corrects for the mistake where the author has a smaller root cardinality for a slice group than the minimum enforced by the
-    //// individual slices. The old validator handled this gracefully, we need to actually generate a corrected cardinality for the 
+    //// individual slices. The old validator handled this gracefully, we need to actually generate a corrected cardinality for the
     //// root.
     //private ElementSchema EnsureMinimumCardinality(ElementSchema schema, IAssertion sliceAssertion, int? min)
     //{
@@ -292,10 +337,10 @@ public class SchemaBuilder : ISchemaBuilder
 
     //}
 
-    private IAssertion createChildrenAssertion(
+    private ChildrenValidator createChildrenAssertion(
         ElementDefinitionNavigator parent,
         SubschemaCollector? subschemas,
-        out IAssertion? valueAssertion, out IAssertion? requiredAssertion)
+        out IAssertion? valueAssertion, out IAssertion? requiredAssertion, out bool hasNamedElementsChild)
     {
         // Recurse into children, make sure we do that on a (shallow) copy of
         // the navigator.
@@ -317,37 +362,66 @@ public class SchemaBuilder : ISchemaBuilder
         bool allowAdditionalChildren = (!atTypeRoot && parentElementDef.IsResourcePlaceholder()) ||
                                        (atTypeRoot && parent.StructureDefinition.Abstract == true);
 
-        return new ChildrenValidator(harvestChildren(childNav, subschemas, out valueAssertion, out requiredAssertion), allowAdditionalChildren);
+        var children = harvestChildren(childNav, subschemas, out valueAssertion, out requiredAssertion, out hasNamedElementsChild);
+
+        // A named-elements extension carrier among this element's children (e.g. fhirAuthorization's
+        // own "extension" child, typed CDSHooksExtensions) means its named extensions are rendered
+        // directly on THIS element in the wire format, not nested under a literal "extension" key -
+        // so THIS element's own children set must accept those unforeseen names too.
+        if (hasNamedElementsChild)
+            allowAdditionalChildren = true;
+
+        return new ChildrenValidator(children, allowAdditionalChildren);
     }
 
     private IReadOnlyDictionary<string, IAssertion> harvestChildren(
         ElementDefinitionNavigator childNav,
         SubschemaCollector? subschemas,
         out IAssertion? valueAssertion,
-        out IAssertion? requiredAssertion
+        out IAssertion? requiredAssertion,
+        out bool hasNamedElementsChild
     )
     {
         var children = new Dictionary<string, IAssertion>();
         var requiredChildren = new List<string>();
         valueAssertion = null;
-            
+        hasNamedElementsChild = false;
+
+        var isLogical = childNav.StructureDefinition.Kind == StructureDefinition.StructureDefinitionKind.Logical;
+
         childNav.MoveToFirstChild();
 
         do
         {
+            // A named-elements extension carrier (extension-style = named-elements) has no literal
+            // JSON property of its own - its named extensions (davinci-crd.version, etc.) appear
+            // directly as siblings of this child in the parent object. So it contributes no entry to
+            // the children dictionary; instead it flags the parent's ChildrenValidator as open.
+            if (isLogical && childNav.Current?.GetExtensionStyle() == "named-elements")
+            {
+                hasNamedElementsChild = true;
+                continue;
+            }
+
             var childPath = childNav.Current?.Base?.Path is { } basePath
                 ? trimPath(basePath)
                 : trimPath(childNav.Path);
-                
+
+            // Logical models can rename the JSON property for a member away from its FHIR element
+            // name (e.g. CDS Hooks' fhirAuthorization.accessToken is serialized as access_token) -
+            // key the children dictionary by that JSON name so ChildNameMatcher matches instances
+            // correctly. Guarded on Kind == Logical so FHIR resource/datatype schemas are unaffected.
+            var childKey = isLogical ? (childNav.Current?.GetJsonName() ?? childPath) : childPath;
+
             if (childNav.Current?.Min is > 0 && !childNav.Current.IsPrimitiveValueConstraint())
             {
                 // If the element is required, we need to add it to the list of required elements.
-                requiredChildren.Add(childPath);
+                requiredChildren.Add(childKey);
             }
-                
+
             var childAssertions = ConvertElement(childNav, subschemas);
 
-            if (children.ContainsKey(childPath))
+            if (children.ContainsKey(childKey))
             {
                 // After we're done processing the previous child, our next elment still appears to have the same path...
                 // This means the previous element was sliced, without us being able to correctly parse the slice. We rather fail than
@@ -364,12 +438,12 @@ public class SchemaBuilder : ISchemaBuilder
                     valueAssertion = childSchema;
                     continue;
                 }
-                children.Add(childPath, childSchema);
+                children.Add(childKey, childSchema);
             }
         }
         while (childNav.MoveToNext());
 
-        requiredAssertion = requiredChildren.Count != 0 ? new RequiredValidator(requiredChildren) : null;;
+        requiredAssertion = requiredChildren.Count != 0 ? new RequiredValidator(requiredChildren) : null;
 
         return children;
 
@@ -377,7 +451,7 @@ public class SchemaBuilder : ISchemaBuilder
         {
             var start = s.LastIndexOf('.') + 1;
             var end = s.EndsWith("[x]") ? s.Length - 3 : s.Length;
-                
+
             if (start < 0 || end <= start)
             {
                 // No path to trim, return the original.
@@ -414,8 +488,8 @@ public class SchemaBuilder : ISchemaBuilder
             var schemaId = "#" + root.Current.ElementId;
             if (sliceName == "@default")
             {
-                // special case: set of rules that apply to all of the remaining content that is not in one of the 
-                // defined slices. 
+                // special case: set of rules that apply to all of the remaining content that is not in one of the
+                // defined slices.
                 defaultSlice = convertElementToSchema(schemaId, root);
             }
             else
@@ -493,7 +567,7 @@ public class SchemaBuilder : ISchemaBuilder
         var sliceAssertions = slicing.Discriminator
             .Select(d => DiscriminatorFactory.Build(slice, d, Source))
             .ToArray();
-            
+
         if (sliceAssertions.All(sa => sa is null))
         {
             var paths = string.Join(',', slicing.Discriminator.Select(d => d.Path));
@@ -524,4 +598,3 @@ public class SchemaBuilder : ISchemaBuilder
 
 
 }
-

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/IdExpectationBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/IdExpectationBuilder.cs
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using System.Collections.Generic;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Firely.Fhir.Validation.Compilation
+{
+    /// <summary>
+    /// The schema builder for the <see cref="IdExpectationValidator"/>.
+    /// </summary>
+    internal class IdExpectationBuilder : ISchemaBuilder
+    {
+        private const string ID_EXPECTATION_URL = "http://hl7.org/fhir/tools/StructureDefinition/id-expectation";
+
+        /// <inheritdoc/>
+        public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
+        {
+            if (conversionMode == ElementConversionMode.ContentReference) yield break;
+
+            var def = nav.Current;
+
+            var code = def.GetPrimitiveExtensionValue(ID_EXPECTATION_URL);
+
+            if (code is null) yield break;
+
+            var expectation = code switch
+            {
+                "optional" => IdExpectation.Optional,
+                "required" => IdExpectation.Required,
+                "prohibited" => IdExpectation.Prohibited,
+                _ => (IdExpectation?)null
+            };
+
+            if (expectation is not null)
+                yield return new IdExpectationValidator(expectation.Value);
+        }
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/ImpliedStringPrefixBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/ImpliedStringPrefixBuilder.cs
@@ -18,8 +18,6 @@ namespace Firely.Fhir.Validation.Compilation
     /// </summary>
     internal class ImpliedStringPrefixBuilder : ISchemaBuilder
     {
-        private const string IMPLIED_STRING_PREFIX_URL = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix";
-
         /// <inheritdoc/>
         public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
         {
@@ -27,7 +25,10 @@ namespace Firely.Fhir.Validation.Compilation
 
             var def = nav.Current;
 
-            var prefix = def.GetStringExtension(IMPLIED_STRING_PREFIX_URL);
+            // Uses the same parsing as ElementDefinition.HasImpliedStringPrefix(), which
+            // TypeReferenceBuilder consults to decide whether to suppress the declared type reference -
+            // so a marker without a usable prefix never silently removes type validation there.
+            var prefix = def.GetImpliedStringPrefix();
             if (prefix is null) yield break;
 
             // The same core type TypeReferenceBuilder would otherwise have referenced directly - by

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/ImpliedStringPrefixBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/ImpliedStringPrefixBuilder.cs
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using System.Collections.Generic;
+using System.Linq;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Firely.Fhir.Validation.Compilation
+{
+    /// <summary>
+    /// The schema builder for the <see cref="ImpliedStringPrefixValidator"/>.
+    /// </summary>
+    internal class ImpliedStringPrefixBuilder : ISchemaBuilder
+    {
+        private const string IMPLIED_STRING_PREFIX_URL = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix";
+
+        /// <inheritdoc/>
+        public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
+        {
+            if (conversionMode == ElementConversionMode.ContentReference) yield break;
+
+            var def = nav.Current;
+
+            var prefix = def.GetStringExtension(IMPLIED_STRING_PREFIX_URL);
+            if (prefix is null) yield break;
+
+            // The same core type TypeReferenceBuilder would otherwise have referenced directly - by
+            // handing it to ImpliedStringPrefixValidator instead, that type's full schema (format regex
+            // included) still gets enforced, just against "prefix + value" rather than the bare wire
+            // value.
+            var schemaUri = def.Type.SingleOrDefault()?.Code is { } typeCode ? Canonical.ForCoreType(typeCode) : (Canonical?)null;
+
+            yield return new ImpliedStringPrefixValidator(prefix, schemaUri);
+        }
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/JsonNullableBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/JsonNullableBuilder.cs
@@ -17,8 +17,6 @@ namespace Firely.Fhir.Validation.Compilation
     /// </summary>
     internal class JsonNullableBuilder : ISchemaBuilder
     {
-        private const string JSON_NULLABLE_URL = "http://hl7.org/fhir/tools/StructureDefinition/json-nullable";
-
         /// <inheritdoc/>
         public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
         {
@@ -26,7 +24,7 @@ namespace Firely.Fhir.Validation.Compilation
 
             var def = nav.Current;
 
-            var isNullable = def.GetBoolExtension(JSON_NULLABLE_URL);
+            var isNullable = def.IsJsonNullable();
 
             if (isNullable is not null)
                 yield return new JsonNullableValidator(isNullable.Value);

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/JsonNullableBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/JsonNullableBuilder.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using System.Collections.Generic;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Firely.Fhir.Validation.Compilation
+{
+    /// <summary>
+    /// The schema builder for the <see cref="JsonNullableValidator"/>.
+    /// </summary>
+    internal class JsonNullableBuilder : ISchemaBuilder
+    {
+        private const string JSON_NULLABLE_URL = "http://hl7.org/fhir/tools/StructureDefinition/json-nullable";
+
+        /// <inheritdoc/>
+        public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
+        {
+            if (conversionMode == ElementConversionMode.ContentReference) yield break;
+
+            var def = nav.Current;
+
+            var isNullable = def.GetBoolExtension(JSON_NULLABLE_URL);
+
+            if (isNullable is not null)
+                yield return new JsonNullableValidator(isNullable.Value);
+        }
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/StandardBuilders.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/StandardBuilders.cs
@@ -38,7 +38,11 @@ public class StandardBuilders(IAsyncResourceResolver source) : ISchemaBuilder
                 new CanonicalBuilder(),
                 new FhirStringBuilder(),
                 new FhirUriBuilder(),
-                new ExtensionContextBuilder()
+                new ExtensionContextBuilder(),
+                new IdExpectationBuilder(),
+                new ImpliedStringPrefixBuilder(),
+                new JsonNullableBuilder(),
+                new TypeSpecifierBuilder()
             ];
 
     /// <inheritdoc/>

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
@@ -77,6 +77,9 @@ namespace Firely.Fhir.Validation.Compilation
             //   type demands) - referencing that schema here would reject every real-world value.
             //   ImpliedStringPrefixBuilder re-runs the declared type's own format regex against
             //   "prefix + value" instead, so this is a deliberate substitution, not a bare relaxation.
+            // Both predicates require a *usable* marker (they run the very same parsing as the builders
+            // that produce the replacement assertion), so a malformed marker leaves the declared type
+            // reference in place rather than silently disabling type validation for the element.
             if (def.HasTypeSpecifier() || def.HasImpliedStringPrefix())
                 yield break;
 

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
@@ -66,6 +66,20 @@ namespace Firely.Fhir.Validation.Compilation
 
             var def = nav.Current;
 
+            // Two logical-model markers make the declared type[] reference inapplicable, each for a
+            // different reason - skip validating against it in both cases:
+            // * type-specifier (see TypeSpecifierBuilder) picks the element's actual type at runtime
+            //   by evaluating a FHIRPath condition; it replaces the declared reference rather than
+            //   adding to it.
+            // * implied-string-prefix (see ImpliedStringPrefixBuilder) documents that the wire value
+            //   omits a prefix the declared type's own format constraint would otherwise require
+            //   (e.g. CDS Hooks' hookInstance is a bare UUID, not urn:uuid:-prefixed as FHIR's uuid
+            //   type demands) - referencing that schema here would reject every real-world value.
+            //   ImpliedStringPrefixBuilder re-runs the declared type's own format regex against
+            //   "prefix + value" instead, so this is a deliberate substitution, not a bare relaxation.
+            if (def.HasTypeSpecifier() || def.HasImpliedStringPrefix())
+                yield break;
+
             if (shouldValidateTypeReference(nav))
             {
                 var typeAssertion = ConvertTypeReferences(def.Type);

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeSpecifierBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeSpecifierBuilder.cs
@@ -5,10 +5,8 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
  */
-using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
 using System.Collections.Generic;
-using System.Linq;
 
 #pragma warning disable CS0618 // Type or member is obsolete
 namespace Firely.Fhir.Validation.Compilation;
@@ -18,10 +16,6 @@ namespace Firely.Fhir.Validation.Compilation;
 /// </summary>
 internal class TypeSpecifierBuilder : ISchemaBuilder
 {
-    private const string TYPE_SPECIFIER_URL = "http://hl7.org/fhir/tools/StructureDefinition/type-specifier";
-    private const string CONDITION_URL = "condition";
-    private const string TYPE_URL = "type";
-
     /// <inheritdoc/>
     public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
     {
@@ -29,31 +23,16 @@ internal class TypeSpecifierBuilder : ISchemaBuilder
 
         var def = nav.Current;
 
-        var cases = def.Extension
-            .Where(e => e.Url == TYPE_SPECIFIER_URL)
-            .Select(toCase)
-            .Where(c => c is not null)
-            .Select(c => c!)
-            .ToList();
+        // Uses the same parsing as ElementDefinition.HasTypeSpecifier(), which TypeReferenceBuilder
+        // consults to decide whether to suppress the declared type reference - so a marker we cannot
+        // turn into a validator here never silently removes type validation there.
+        var cases = def.GetTypeSpecifierCases();
 
         if (cases.Count == 0) yield break;
 
         // Since a type-specifier picks the actual type at runtime, it replaces the normal
         // type[]-based type reference/label rather than adding to it.
         yield return new TypeSpecifierValidator(cases);
-
-        static TypeSpecifierCase? toCase(Extension typeSpecifier)
-        {
-            var condition = subExtensionValue(typeSpecifier, CONDITION_URL);
-            var type = subExtensionValue(typeSpecifier, TYPE_URL);
-
-            return condition is not null && type is not null
-                ? new TypeSpecifierCase(condition, new Canonical(type))
-                : null;
-        }
-
-        static string? subExtensionValue(Extension parent, string url) =>
-            (parent.Extension?.Find(e => e.Url == url)?.Value as PrimitiveType)?.JsonValue?.ToString();
     }
 }
 

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeSpecifierBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeSpecifierBuilder.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using System.Collections.Generic;
+using System.Linq;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Firely.Fhir.Validation.Compilation;
+
+/// <summary>
+/// The schema builder for the <see cref="TypeSpecifierValidator"/>.
+/// </summary>
+internal class TypeSpecifierBuilder : ISchemaBuilder
+{
+    private const string TYPE_SPECIFIER_URL = "http://hl7.org/fhir/tools/StructureDefinition/type-specifier";
+    private const string CONDITION_URL = "condition";
+    private const string TYPE_URL = "type";
+
+    /// <inheritdoc/>
+    public IEnumerable<IAssertion> Build(ElementDefinitionNavigator nav, ElementConversionMode? conversionMode = ElementConversionMode.Full)
+    {
+        if (conversionMode == ElementConversionMode.ContentReference) yield break;
+
+        var def = nav.Current;
+
+        var cases = def.Extension
+            .Where(e => e.Url == TYPE_SPECIFIER_URL)
+            .Select(toCase)
+            .Where(c => c is not null)
+            .Select(c => c!)
+            .ToList();
+
+        if (cases.Count == 0) yield break;
+
+        // Since a type-specifier picks the actual type at runtime, it replaces the normal
+        // type[]-based type reference/label rather than adding to it.
+        yield return new TypeSpecifierValidator(cases);
+
+        static TypeSpecifierCase? toCase(Extension typeSpecifier)
+        {
+            var condition = subExtensionValue(typeSpecifier, CONDITION_URL);
+            var type = subExtensionValue(typeSpecifier, TYPE_URL);
+
+            return condition is not null && type is not null
+                ? new TypeSpecifierCase(condition, new Canonical(type))
+                : null;
+        }
+
+        static string? subExtensionValue(Extension parent, string url) =>
+            (parent.Extension?.Find(e => e.Url == url)?.Value as PrimitiveType)?.JsonValue?.ToString();
+    }
+}
+
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.Model;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Firely.Fhir.Validation.Compilation;
@@ -25,6 +26,9 @@ internal static class ToolsExtensions
     private const string JSON_PROPERTY_KEY = "http://hl7.org/fhir/tools/StructureDefinition/json-property-key";
     private const string TYPE_SPECIFIER = "http://hl7.org/fhir/tools/StructureDefinition/type-specifier";
     private const string IMPLIED_STRING_PREFIX = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix";
+    private const string JSON_NULLABLE = "http://hl7.org/fhir/tools/StructureDefinition/json-nullable";
+    private const string TYPE_SPECIFIER_CONDITION = "condition";
+    private const string TYPE_SPECIFIER_TYPE = "type";
 
     /// <summary>
     /// The literal JSON property name for this element, if it carries a <c>json-name</c> extension
@@ -51,15 +55,57 @@ internal static class ToolsExtensions
     /// Whether this element's actual type is picked at runtime by evaluating a FHIRPath condition
     /// (per the <c>type-specifier</c> extension) rather than by a fixed <c>type[]</c> reference.
     /// </summary>
+    /// <remarks>Only usable (well-formed) type-specifiers count: a marker we cannot turn into a
+    /// <see cref="TypeSpecifierValidator"/> must not cause the declared type reference to be
+    /// suppressed, since that would leave the element unvalidated altogether.</remarks>
     internal static bool HasTypeSpecifier(this ElementDefinition ed) =>
-        ed.Extension.Any(e => e.Url == TYPE_SPECIFIER);
+        ed.GetTypeSpecifierCases().Count > 0;
+
+    /// <summary>
+    /// The condition/type pairs of this element's <c>type-specifier</c> extensions. Markers missing
+    /// either sub-extension (or carrying a non-primitive value) are skipped.
+    /// </summary>
+    internal static List<TypeSpecifierCase> GetTypeSpecifierCases(this ElementDefinition ed) =>
+        ed.Extension
+            .Where(e => e.Url == TYPE_SPECIFIER)
+            .Select(toCase)
+            .OfType<TypeSpecifierCase>()
+            .ToList();
+
+    private static TypeSpecifierCase? toCase(Extension typeSpecifier)
+    {
+        var condition = subExtensionValue(typeSpecifier, TYPE_SPECIFIER_CONDITION);
+        var type = subExtensionValue(typeSpecifier, TYPE_SPECIFIER_TYPE);
+
+        return condition is not null && type is not null
+            ? new TypeSpecifierCase(condition, new Canonical(type))
+            : null;
+
+        static string? subExtensionValue(Extension parent, string url) =>
+            (parent.Extension?.Find(e => e.Url == url)?.Value as PrimitiveType)?.JsonValue?.ToString();
+    }
 
     /// <summary>
     /// Whether this element's wire value omits a prefix that its declared type's own format
     /// constraint would otherwise require (per the <c>implied-string-prefix</c> extension).
     /// </summary>
+    /// <remarks>See the remarks on <see cref="HasTypeSpecifier"/> - a marker without a usable prefix
+    /// value does not count.</remarks>
     internal static bool HasImpliedStringPrefix(this ElementDefinition ed) =>
-        ed.Extension.Any(e => e.Url == IMPLIED_STRING_PREFIX);
+        ed.GetImpliedStringPrefix() is not null;
+
+    /// <summary>
+    /// The prefix omitted from this element's wire value, if it carries a usable
+    /// <c>implied-string-prefix</c> extension.
+    /// </summary>
+    internal static string? GetImpliedStringPrefix(this ElementDefinition ed) =>
+        ed.GetPrimitiveExtensionValue(IMPLIED_STRING_PREFIX) is { Length: > 0 } prefix ? prefix : null;
+
+    /// <summary>
+    /// Whether a JSON <c>null</c> is a legitimate value for this element (per the <c>json-nullable</c>
+    /// extension), or <c>null</c> when the element does not say.
+    /// </summary>
+    internal static bool? IsJsonNullable(this ElementDefinition ed) => ed.GetBoolExtension(JSON_NULLABLE);
 
     /// <summary>
     /// Reads an extension's value as a string regardless of its declared primitive type

--- a/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using System.Linq;
+
+namespace Firely.Fhir.Validation.Compilation;
+
+/// <summary>
+/// Helpers for reading the <c>hl7.fhir.uv.tools</c> extension vocabulary used on logical models
+/// (e.g. CDS Hooks / Da Vinci CRD) to describe their JSON shape.
+/// </summary>
+internal static class ToolsExtensions
+{
+    // Both spellings are seen in the wild across hl7.fhir.uv.tools/CRD package versions.
+    private const string JSON_NAME = "http://hl7.org/fhir/tools/StructureDefinition/json-name";
+    private const string JSON_NAME_LEGACY = "http://hl7.org/fhir/tools/StructureDefinition/elementdefinition-json-name";
+    private const string EXTENSION_STYLE = "http://hl7.org/fhir/tools/StructureDefinition/extension-style";
+    private const string EXTENSION_STYLE_LEGACY = "http://hl7.org/fhir/tools/StructureDefinition/elementdefinition-extension-style";
+    private const string JSON_PROPERTY_KEY = "http://hl7.org/fhir/tools/StructureDefinition/json-property-key";
+    private const string TYPE_SPECIFIER = "http://hl7.org/fhir/tools/StructureDefinition/type-specifier";
+    private const string IMPLIED_STRING_PREFIX = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix";
+
+    /// <summary>
+    /// The literal JSON property name for this element, if it carries a <c>json-name</c> extension
+    /// (used by logical models to represent snake_case or otherwise non-FHIR-conformant member names).
+    /// </summary>
+    internal static string? GetJsonName(this ElementDefinition ed) =>
+        ed.GetPrimitiveExtensionValue(JSON_NAME) ?? ed.GetPrimitiveExtensionValue(JSON_NAME_LEGACY);
+
+    /// <summary>
+    /// The <c>extension-style</c> code (<c>none</c>/<c>fhir-extensions</c>/<c>named-elements</c>) for this
+    /// element, if present.
+    /// </summary>
+    internal static string? GetExtensionStyle(this ElementDefinition ed) =>
+        ed.GetPrimitiveExtensionValue(EXTENSION_STYLE) ?? ed.GetPrimitiveExtensionValue(EXTENSION_STYLE_LEGACY);
+
+    /// <summary>
+    /// The name of the sibling child element whose value should be used as the JSON object key when this
+    /// repeating element is rendered as a JSON object (keyed by that child) rather than a JSON array.
+    /// </summary>
+    internal static string? GetJsonPropertyKey(this ElementDefinition ed) =>
+        ed.GetPrimitiveExtensionValue(JSON_PROPERTY_KEY);
+
+    /// <summary>
+    /// Whether this element's actual type is picked at runtime by evaluating a FHIRPath condition
+    /// (per the <c>type-specifier</c> extension) rather than by a fixed <c>type[]</c> reference.
+    /// </summary>
+    internal static bool HasTypeSpecifier(this ElementDefinition ed) =>
+        ed.Extension.Any(e => e.Url == TYPE_SPECIFIER);
+
+    /// <summary>
+    /// Whether this element's wire value omits a prefix that its declared type's own format
+    /// constraint would otherwise require (per the <c>implied-string-prefix</c> extension).
+    /// </summary>
+    internal static bool HasImpliedStringPrefix(this ElementDefinition ed) =>
+        ed.Extension.Any(e => e.Url == IMPLIED_STRING_PREFIX);
+
+    /// <summary>
+    /// Reads an extension's value as a string regardless of its declared primitive type
+    /// (<c>FhirString</c>, <c>Code</c>, etc.) - unlike <c>GetStringExtension</c>, which only recognizes
+    /// <c>FhirString</c> and silently returns <c>null</c> for bound <c>code</c>-typed extensions such as
+    /// <c>json-property-key</c>, <c>extension-style</c> and <c>id-expectation</c>.
+    /// </summary>
+    internal static string? GetPrimitiveExtensionValue(this ElementDefinition ed, string url) =>
+        (ed.GetExtension(url)?.Value as PrimitiveType)?.JsonValue?.ToString();
+}
+

--- a/src/Firely.Fhir.Validation/Impl/IdExpectationValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/IdExpectationValidator.cs
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// The possible values for the id-expectation marker extension.
+    /// </summary>
+    public enum IdExpectation
+    {
+        /// <summary>
+        /// The contained/referenced resource may carry an id.
+        /// </summary>
+        Optional,
+
+        /// <summary>
+        /// The contained/referenced resource must carry an id.
+        /// </summary>
+        Required,
+
+        /// <summary>
+        /// The contained/referenced resource must not carry an id.
+        /// </summary>
+        Prohibited
+    }
+
+    /// <summary>
+    /// Asserts the expectation on the presence of an id on a contained/referenced resource, as recorded
+    /// by the id-expectation extension.
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class IdExpectationValidator : BasicValidator
+    {
+        /// <summary>
+        /// The expectation on the presence of an id on the contained/referenced resource.
+        /// </summary>
+        [DataMember]
+        public IdExpectation Expectation { get; private set; }
+
+        /// <summary>
+        /// Initializes a new IdExpectationValidator given an expectation.
+        /// </summary>
+        /// <param name="expectation"></param>
+        public IdExpectationValidator(IdExpectation expectation)
+        {
+            Expectation = expectation;
+        }
+
+        /// <inheritdoc />
+        protected override string Key => "id-expectation";
+
+        /// <inheritdoc />
+        protected override object Value => Expectation.ToString().ToLowerInvariant();
+
+        /// <inheritdoc />
+        internal override ResultReport BasicValidate(PocoNode input, ValidationSettings vc, ValidationState s)
+        {
+            var hasId = input.Child("id") is not null;
+
+            return Expectation switch
+            {
+                IdExpectation.Required when !hasId =>
+                    new IssueAssertion(Issue.CONTENT_INCORRECT_OCCURRENCE, "This contained resource is required to carry an 'id', but none was found.")
+                        .AsResult(s, input, nameof(IdExpectationValidator), this),
+                IdExpectation.Prohibited when hasId =>
+                    new IssueAssertion(Issue.CONTENT_INCORRECT_OCCURRENCE, "This contained resource must not carry an 'id', but one was found.")
+                        .AsResult(s, input, nameof(IdExpectationValidator), this),
+                _ => ResultReport.SUCCESS
+            };
+        }
+    }
+}

--- a/src/Firely.Fhir.Validation/Impl/ImpliedStringPrefixValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ImpliedStringPrefixValidator.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// Records that the wire value of a string-like element omits a prefix that the underlying
+    /// FHIR type would otherwise require, as recorded by the implied-string-prefix extension.
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class ImpliedStringPrefixValidator : BasicValidator
+    {
+        /// <summary>
+        /// The prefix that is implied but omitted from the wire value.
+        /// </summary>
+        [DataMember]
+        public string Prefix { get; private set; }
+
+        /// <summary>
+        /// The declared type this element would normally be validated against (suppressed for this
+        /// element by TypeReferenceBuilder, since the wire value is missing <see cref="Prefix"/>).
+        /// </summary>
+        [DataMember]
+        public Canonical? SchemaUri { get; private set; }
+
+        /// <summary>
+        /// Initializes a new ImpliedStringPrefixValidator given a prefix.
+        /// </summary>
+        /// <param name="prefix"></param>
+        /// <param name="schemaUri">The declared type's schema, to re-run against "prefix + value".</param>
+        public ImpliedStringPrefixValidator(string prefix, Canonical? schemaUri = null)
+        {
+            Prefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
+            SchemaUri = schemaUri;
+        }
+
+        /// <inheritdoc />
+        protected override string Key => "implied-string-prefix";
+
+        /// <inheritdoc />
+        protected override object Value => Prefix;
+
+        /// <inheritdoc />
+        internal override ResultReport BasicValidate(PocoNode input, ValidationSettings vc, ValidationState s)
+        {
+            // No declared type to fall back on (e.g. couldn't be determined at compile time), so
+            // there's nothing to re-check beyond the prefix having been recorded.
+            if (SchemaUri is not { } schemaUri) return ResultReport.SUCCESS;
+
+            // Re-run the declared type's own schema (e.g. FHIR's uuid regex) against a value with the
+            // implied prefix restored, instead of against the wire value directly - reusing the exact
+            // same type schema TypeReferenceBuilder would otherwise have referenced.
+            if (input.Poco is not PrimitiveType primitive || primitive.JsonValue is null) return ResultReport.SUCCESS;
+
+            var prefixedValue = Prefix + PrimitiveTypeConverter.ConvertTo<string>(primitive.JsonValue);
+            var clone = (PrimitiveType)primitive.DeepCopy();
+            clone.JsonValue = prefixedValue;
+
+            // Keep the original node's parent/name/index (for correct issue locations) and only swap
+            // in the prefixed clone as its Poco.
+            var syntheticNode = input with { Poco = clone };
+            return new SchemaReferenceValidator(schemaUri).ValidateOne(syntheticNode, vc, s);
+        }
+    }
+}

--- a/src/Firely.Fhir.Validation/Impl/JsonNullableValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/JsonNullableValidator.cs
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// Records that a JSON null value is a legitimate value for this element, as recorded
+    /// by the json-nullable extension.
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class JsonNullableValidator : BasicValidator
+    {
+        /// <summary>
+        /// Whether a JSON null value is a legitimate value for this element.
+        /// </summary>
+        [DataMember]
+        public bool IsNullable { get; private set; }
+
+        /// <summary>
+        /// Initializes a new JsonNullableValidator given a nullable flag.
+        /// </summary>
+        /// <param name="isNullable"></param>
+        public JsonNullableValidator(bool isNullable)
+        {
+            IsNullable = isNullable;
+        }
+
+        /// <inheritdoc />
+        protected override string Key => "json-nullable";
+
+        /// <inheritdoc />
+        protected override object Value => IsNullable;
+
+        /// <inheritdoc />
+        internal override ResultReport BasicValidate(PocoNode input, ValidationSettings vc, ValidationState s) =>
+            // Documentation/schema only marker: JSON null never yields a child node to validate against per FHIR.
+            ResultReport.SUCCESS;
+    }
+}

--- a/src/Firely.Fhir.Validation/Impl/KeyedObjectValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/KeyedObjectValidator.cs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Newtonsoft.Json.Linq;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// Validates a repeating logical-model element that is rendered as a JSON object keyed by an
+    /// arbitrary map key (per the <c>json-property-key</c> extension), rather than as a JSON array -
+    /// e.g. CDS Hooks' <c>prefetch</c> (keyed by prefetch key) or Da Vinci CRD's flat
+    /// <c>davinci-crd.configuration</c> code -> value map.
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class KeyedObjectValidator : IValidatable
+    {
+        /// <summary>
+        /// The assertion each entry (JSON property value) of the keyed object is validated against.
+        /// </summary>
+        [DataMember]
+        public IAssertion EntryAssertion { get; private set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="KeyedObjectValidator"/> given the assertion each entry should be
+        /// validated against.
+        /// </summary>
+        public KeyedObjectValidator(IAssertion entryAssertion)
+        {
+            EntryAssertion = entryAssertion ?? throw new ArgumentNullException(nameof(entryAssertion));
+        }
+
+        /// <inheritdoc />
+        public JToken ToJson() =>
+            new JProperty("keyed-object", EntryAssertion.ToJson().MakeNestedProp());
+
+        /// <inheritdoc />
+        ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
+        {
+            // Each JSON property of the keyed object is a single map entry (not a repeating group),
+            // so flatten the named PocoNodeOrList groups into individual entry nodes.
+            var entries = input.Children().SelectMany(c => c).ToList();
+
+            var evidence = entries.Select(entry =>
+                EntryAssertion.ValidateOne(entry, vc, state.UpdateLocation(vs => vs.ToChild(entry.Name))));
+
+            return ResultReport.Combine(evidence.ToList());
+        }
+    }
+}

--- a/src/Firely.Fhir.Validation/Impl/KeyedObjectValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/KeyedObjectValidator.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
 using Newtonsoft.Json.Linq;
 using System;
 using System.ComponentModel;
@@ -37,17 +38,49 @@ namespace Firely.Fhir.Validation
         public IAssertion EntryAssertion { get; private set; }
 
         /// <summary>
-        /// Initializes a new <see cref="KeyedObjectValidator"/> given the assertion each entry should be
-        /// validated against.
+        /// Lower bound on the number of entries (JSON properties) of the keyed object. If not set,
+        /// there is no lower bound.
         /// </summary>
-        public KeyedObjectValidator(IAssertion entryAssertion)
+        /// <remarks>This is the cardinality declared on the logical element itself: since the element is
+        /// rendered as a single JSON object rather than as an array, its cardinality constrains the map
+        /// entries, not the number of occurrences of the object.</remarks>
+        [DataMember]
+        public int? Min { get; private set; }
+
+        /// <summary>
+        /// Upper bound on the number of entries (JSON properties) of the keyed object. If not set,
+        /// there is no upper bound.
+        /// </summary>
+        /// <remarks>See the remarks on <see cref="Min"/>.</remarks>
+        [DataMember]
+        public int? Max { get; private set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="KeyedObjectValidator"/> given the assertion each entry should be
+        /// validated against, and the cardinality the entries should adhere to.
+        /// </summary>
+        public KeyedObjectValidator(IAssertion entryAssertion, int? min = null, int? max = null)
         {
             EntryAssertion = entryAssertion ?? throw new ArgumentNullException(nameof(entryAssertion));
+
+            if (min < 0 || max < 0)
+                throw new IncorrectElementDefinitionException("Cardinality cannot be lower than 0.");
+            if (min > max)
+                throw new IncorrectElementDefinitionException("Upper cardinality must be higher than the lower cardinality.");
+
+            Min = min;
+            Max = max;
         }
 
         /// <inheritdoc />
         public JToken ToJson() =>
-            new JProperty("keyed-object", EntryAssertion.ToJson().MakeNestedProp());
+            new JProperty("keyed-object", new JObject(
+                new JProperty("cardinality", CardinalityDisplay),
+                new JProperty("entry", EntryAssertion.ToJson().MakeNestedProp())));
+
+        private bool inRange(int x) => (!Min.HasValue || x >= Min.Value) && (!Max.HasValue || x <= Max.Value);
+
+        private string CardinalityDisplay => $"{Min?.ToString() ?? "<-"}..{Max?.ToString() ?? "*"}";
 
         /// <inheritdoc />
         ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
@@ -57,9 +90,17 @@ namespace Firely.Fhir.Validation
             var entries = input.Children().SelectMany(c => c).ToList();
 
             var evidence = entries.Select(entry =>
-                EntryAssertion.ValidateOne(entry, vc, state.UpdateLocation(vs => vs.ToChild(entry.Name))));
+                EntryAssertion.ValidateOne(entry, vc, state.UpdateLocation(vs => vs.ToChild(entry.Name)))).ToList();
 
-            return ResultReport.Combine(evidence.ToList());
+            // The declared cardinality of the logical element applies to the map entries: the element
+            // itself always occurs exactly once (as the JSON object container), so the normal
+            // CardinalityValidator is not built for this representation and the check happens here.
+            if (!inRange(entries.Count))
+                evidence.Add(new IssueAssertion(Issue.CONTENT_INCORRECT_OCCURRENCE,
+                        $"Instance count at element '{input.Name}' is {entries.Count}, which is not within the specified cardinality of {CardinalityDisplay}")
+                    .AsResult(state, input, nameof(KeyedObjectValidator), this));
+
+            return ResultReport.Combine(evidence);
         }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/LogicalModelSchema.cs
+++ b/src/Firely.Fhir.Validation/Impl/LogicalModelSchema.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// An <see cref="ElementSchema"/> that represents a FHIR logical model (<c>StructureDefinition.kind = "logical"</c>).
+    /// </summary>
+    [DataContract]
+    public class LogicalModelSchema : FhirSchema
+    {
+        /// <summary>
+        /// Constructs a new <see cref="LogicalModelSchema"/>
+        /// </summary>
+        public LogicalModelSchema(StructureDefinitionInformation structureDefinition, params IAssertion[] members) : base(structureDefinition, members.AsEnumerable())
+        {
+            // nothing
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="LogicalModelSchema"/>
+        /// </summary>
+        public LogicalModelSchema(StructureDefinitionInformation structureDefinition, IEnumerable<IAssertion> members) : base(structureDefinition, members)
+        {
+            // nothing
+        }
+
+        /// <inheritdoc />
+        internal override ResultReport ValidateInternal(IEnumerable<PocoNode> input, ValidationSettings vc, ValidationState state)
+        {
+            // Schemas representing the root of a logical model cannot meaningfully be used as a GroupValidatable,
+            // so we'll turn this into a normal IValidatable.
+            var results = input.Select(i => ValidateInternal(i, vc, state));
+            return ResultReport.Combine(results.ToList());
+        }
+
+        /// <inheritdoc />
+        internal override ResultReport ValidateInternal(PocoNode input, ValidationSettings vc, ValidationState state) =>
+            // Unlike DatatypeSchema, a logical model's declared "type" is a canonical url (e.g.
+            // http://hl7.org/fhir/tools/StructureDefinition/CDSHooksRequest), not a FHIR type name that
+            // can be compared against the instance's runtime type name - there is no abstract-type
+            // indirection to perform here, just validate the members directly.
+            base.ValidateInternal(input, vc, state);
+
+        /// <inheritdoc/>
+        internal override string FhirSchemaKind => "logical";
+    }
+}
+#pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Firely.Fhir.Validation/Impl/NamedExtensionsValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/NamedExtensionsValidator.cs
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using Hl7.Fhir.Utility;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// Marks a logical-model element as a named-elements extension carrier (per the
+    /// <c>extension-style</c> extension) - e.g. CDS Hooks' <c>fhirAuthorization.extension</c>, whose
+    /// named properties (<c>davinci-crd.version</c>, etc.) are named extensions rather than a FHIR
+    /// array of <c>Extension</c>+<c>url</c>.
+    /// </summary>
+    /// <remarks>
+    /// A named extension's JSON name is resolved to its defining <c>StructureDefinition</c> by
+    /// passing it straight into <see cref="ValidationSettings.ConformanceResourceResolver"/> as if it
+    /// were a canonical - the resolver is expected to maintain a cache mapping those names to the
+    /// actual profiles. The resulting profile's schema is then used to validate the extension's value.
+    /// </remarks>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class NamedExtensionsValidator : IValidatable
+    {
+        /// <summary>
+        /// The names of the children of this element that are declared in the profile - any other
+        /// child found on the instance is considered a named extension.
+        /// </summary>
+        [DataMember]
+        public IReadOnlyCollection<string> KnownChildNames { get; private set; }
+
+        /// <summary>
+        /// Initializes a new NamedExtensionsValidator.
+        /// </summary>
+        public NamedExtensionsValidator(IEnumerable<string> knownChildNames)
+        {
+            KnownChildNames = knownChildNames?.ToArray() ?? throw new ArgumentNullException(nameof(knownChildNames));
+        }
+
+        /// <inheritdoc />
+        public JToken ToJson() => new JProperty("named-extensions", true);
+
+        /// <inheritdoc />
+        ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
+        {
+            if (vc.ConformanceResourceResolver is null)
+                throw new ArgumentException($"Cannot validate because {nameof(ValidationSettings)} does not contain a ConformanceResourceResolver.");
+
+            var namedExtensions = input.Children().Where(c => !KnownChildNames.Contains(c.Name)).SelectMany(c => c).ToList();
+
+            return ResultReport.Combine([ ..namedExtensions.Select(child => validate(child, vc, state)) ]);
+        }
+
+        private ResultReport validate(PocoNode child, ValidationSettings vc, ValidationState state)
+        {
+            var result = TaskHelper.Await(() => vc.ConformanceResourceResolver!.TryResolveByCanonicalUriAsync(child.Name));
+            if (!result.Success || result.Value is not IConformanceResource {Url: {} url } sd)
+            {
+                return new IssueAssertion(Issue.UNAVAILABLE_REFERENCED_PROFILE,
+                    $"Cannot resolve named extension '{child.Name}' to a StructureDefinition.")
+                    .AsResult(state, child, nameof(NamedExtensionsValidator), this);
+            }
+
+            return new SchemaReferenceValidator(url).ValidateOne(child, vc, state);
+        }
+    }
+}

--- a/src/Firely.Fhir.Validation/Impl/TypeSpecifierValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/TypeSpecifierValidator.cs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.FhirPath;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Terminology;
+using Hl7.Fhir.Support;
+using Hl7.FhirPath;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// A single condition/type pair of a <see cref="TypeSpecifierValidator"/> - if <see cref="Condition"/>
+    /// evaluates to true (against the containing resource), the element's actual type is <see cref="Type"/>.
+    /// </summary>
+    public record TypeSpecifierCase(string Condition, Canonical Type);
+
+    /// <summary>
+    /// Validates a logical-model element whose actual type is picked by evaluating a FHIRPath condition
+    /// against the containing resource, rather than by a fixed <c>type[x]</c>-suffix or type list - e.g.
+    /// CDS Hooks' <c>CDSHooksRequest.context</c>, whose type depends on <c>%resource.hook</c>.
+    /// </summary>
+    [DataContract]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public class TypeSpecifierValidator : IValidatable
+    {
+        /// <summary>
+        /// The condition/type cases, evaluated in order - the first matching condition wins.
+        /// </summary>
+        [DataMember]
+        public IReadOnlyList<TypeSpecifierCase> Cases { get; private set; }
+
+        /// <summary>
+        /// The type to use when none of the <see cref="Cases"/> match, if any.
+        /// </summary>
+        [DataMember]
+        public Canonical? DefaultType { get; private set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="TypeSpecifierValidator"/>.
+        /// </summary>
+        public TypeSpecifierValidator(IEnumerable<TypeSpecifierCase> cases, Canonical? defaultType = null)
+        {
+            Cases = cases?.ToList() ?? throw new ArgumentNullException(nameof(cases));
+            DefaultType = defaultType;
+        }
+
+        /// <inheritdoc />
+        public JToken ToJson() =>
+            new JProperty("type-specifier", new JObject(
+                new JProperty("cases", new JArray(Cases.Select(c => new JObject(
+                    new JProperty("condition", c.Condition),
+                    new JProperty("type", c.Type.ToString()))))),
+                new JProperty("default", DefaultType?.ToString())));
+
+        /// <inheritdoc />
+        ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
+        {
+            var compiler = vc.FhirPathCompiler ?? FhirPathValidator.DefaultCompiler;
+
+            foreach (var @case in Cases)
+            {
+                if (evaluate(@case.Condition, input, compiler))
+                    return new SchemaReferenceValidator(@case.Type).ValidateOne(input, vc, state);
+            }
+
+            if (DefaultType is { } defaultType)
+                return new SchemaReferenceValidator(defaultType).ValidateOne(input, vc, state);
+
+            return new IssueAssertion(Issue.CONTENT_ELEMENT_HAS_INCORRECT_TYPE,
+                    "None of the type-specifier conditions matched, and no default type is declared.")
+                .AsResult(state, input, nameof(TypeSpecifierValidator), this);
+        }
+
+        private static bool evaluate(string condition, PocoNode input, FhirPathCompiler compiler)
+        {
+            CompiledExpression compiled;
+            try
+            {
+                compiled = compiler.Compile(condition);
+            }
+            catch (Exception ex)
+            {
+                throw new IncorrectElementDefinitionException($"Error during compilation of type-specifier condition ({condition})", ex);
+            }
+
+            // type-specifier conditions are simple equality checks against the containing resource
+            // (e.g. %resource.hook = 'order-sign'), so no terminology service is wired up here.
+            var root = input;
+            while (root.Parent is { } parent) root = parent;
+
+            var context = new FhirEvaluationContext { Resource = root, RootResource = root };
+
+            return compiled.IsTrue(input, context);
+        }
+    }
+}

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -208,7 +208,9 @@ Firely.Fhir.Validation.JsonNullableValidator.IsNullable.get -> bool
 Firely.Fhir.Validation.JsonNullableValidator.JsonNullableValidator(bool isNullable) -> void
 Firely.Fhir.Validation.KeyedObjectValidator
 Firely.Fhir.Validation.KeyedObjectValidator.EntryAssertion.get -> Firely.Fhir.Validation.IAssertion!
-Firely.Fhir.Validation.KeyedObjectValidator.KeyedObjectValidator(Firely.Fhir.Validation.IAssertion! entryAssertion) -> void
+Firely.Fhir.Validation.KeyedObjectValidator.KeyedObjectValidator(Firely.Fhir.Validation.IAssertion! entryAssertion, int? min = null, int? max = null) -> void
+Firely.Fhir.Validation.KeyedObjectValidator.Max.get -> int?
+Firely.Fhir.Validation.KeyedObjectValidator.Min.get -> int?
 Firely.Fhir.Validation.KeyedObjectValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.LogicalModelSchema
 Firely.Fhir.Validation.LogicalModelSchema.LogicalModelSchema(Firely.Fhir.Validation.StructureDefinitionInformation! structureDefinition, params Firely.Fhir.Validation.IAssertion![]! members) -> void

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -167,6 +167,17 @@ Firely.Fhir.Validation.IGroupValidatable
 Firely.Fhir.Validation.IGroupValidatable.Validate(System.Collections.Generic.IEnumerable<Hl7.Fhir.Model.PocoNode!>! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state) -> Firely.Fhir.Validation.ResultReport!
 Firely.Fhir.Validation.IJsonSerializable
 Firely.Fhir.Validation.IJsonSerializable.ToJson() -> Newtonsoft.Json.Linq.JToken!
+Firely.Fhir.Validation.IdExpectation
+Firely.Fhir.Validation.IdExpectation.Optional = 0 -> Firely.Fhir.Validation.IdExpectation
+Firely.Fhir.Validation.IdExpectation.Required = 1 -> Firely.Fhir.Validation.IdExpectation
+Firely.Fhir.Validation.IdExpectation.Prohibited = 2 -> Firely.Fhir.Validation.IdExpectation
+Firely.Fhir.Validation.IdExpectationValidator
+Firely.Fhir.Validation.IdExpectationValidator.Expectation.get -> Firely.Fhir.Validation.IdExpectation
+Firely.Fhir.Validation.IdExpectationValidator.IdExpectationValidator(Firely.Fhir.Validation.IdExpectation expectation) -> void
+Firely.Fhir.Validation.ImpliedStringPrefixValidator
+Firely.Fhir.Validation.ImpliedStringPrefixValidator.ImpliedStringPrefixValidator(string! prefix, Firely.Fhir.Validation.Canonical? schemaUri = null) -> void
+Firely.Fhir.Validation.ImpliedStringPrefixValidator.Prefix.get -> string!
+Firely.Fhir.Validation.ImpliedStringPrefixValidator.SchemaUri.get -> Firely.Fhir.Validation.Canonical?
 Firely.Fhir.Validation.InMemoryExternalReferenceResolver
 Firely.Fhir.Validation.InMemoryExternalReferenceResolver.InMemoryExternalReferenceResolver() -> void
 Firely.Fhir.Validation.InMemoryExternalReferenceResolver.ResolveAsync(string! reference) -> System.Threading.Tasks.Task<object?>!
@@ -192,6 +203,16 @@ Firely.Fhir.Validation.IssueAssertion.Type.get -> Hl7.Fhir.Model.OperationOutcom
 Firely.Fhir.Validation.IValidatable
 Firely.Fhir.Validation.IssueTransformer
 Firely.Fhir.Validation.IValidatable.Validate(Hl7.Fhir.Model.PocoNode! input, Firely.Fhir.Validation.ValidationSettings! vc, Firely.Fhir.Validation.ValidationState! state) -> Firely.Fhir.Validation.ResultReport!
+Firely.Fhir.Validation.JsonNullableValidator
+Firely.Fhir.Validation.JsonNullableValidator.IsNullable.get -> bool
+Firely.Fhir.Validation.JsonNullableValidator.JsonNullableValidator(bool isNullable) -> void
+Firely.Fhir.Validation.KeyedObjectValidator
+Firely.Fhir.Validation.KeyedObjectValidator.EntryAssertion.get -> Firely.Fhir.Validation.IAssertion!
+Firely.Fhir.Validation.KeyedObjectValidator.KeyedObjectValidator(Firely.Fhir.Validation.IAssertion! entryAssertion) -> void
+Firely.Fhir.Validation.KeyedObjectValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
+Firely.Fhir.Validation.LogicalModelSchema
+Firely.Fhir.Validation.LogicalModelSchema.LogicalModelSchema(Firely.Fhir.Validation.StructureDefinitionInformation! structureDefinition, params Firely.Fhir.Validation.IAssertion![]! members) -> void
+Firely.Fhir.Validation.LogicalModelSchema.LogicalModelSchema(Firely.Fhir.Validation.StructureDefinitionInformation! structureDefinition, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IAssertion!>! members) -> void
 Firely.Fhir.Validation.MaxLengthValidator
 Firely.Fhir.Validation.MaxLengthValidator.MaximumLength.get -> int
 Firely.Fhir.Validation.MaxLengthValidator.MaxLengthValidator(int maximumLength) -> void
@@ -210,6 +231,10 @@ Firely.Fhir.Validation.MultiElementSchemaResolver.GetSchema(Firely.Fhir.Validati
 Firely.Fhir.Validation.MultiElementSchemaResolver.MultiElementSchemaResolver(params Firely.Fhir.Validation.IElementSchemaResolver![]! sources) -> void
 Firely.Fhir.Validation.MultiElementSchemaResolver.MultiElementSchemaResolver(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.IElementSchemaResolver!>! sources) -> void
 Firely.Fhir.Validation.MultiElementSchemaResolver.Sources.get -> System.Collections.Generic.IReadOnlyCollection<Firely.Fhir.Validation.IElementSchemaResolver!>!
+Firely.Fhir.Validation.NamedExtensionsValidator
+Firely.Fhir.Validation.NamedExtensionsValidator.KnownChildNames.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Firely.Fhir.Validation.NamedExtensionsValidator.NamedExtensionsValidator(System.Collections.Generic.IEnumerable<string!>! knownChildNames) -> void
+Firely.Fhir.Validation.NamedExtensionsValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.PathSelectorValidator
 Firely.Fhir.Validation.PathSelectorValidator.Other.get -> Firely.Fhir.Validation.IAssertion!
 Firely.Fhir.Validation.PathSelectorValidator.Path.get -> string!
@@ -309,6 +334,28 @@ Firely.Fhir.Validation.TraceAssertion.Message.get -> string!
 Firely.Fhir.Validation.TraceAssertion.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.TraceAssertion.TraceAssertion(string! location, string! message) -> void
 Firely.Fhir.Validation.TypeNameMapper
+Firely.Fhir.Validation.TypeSpecifierCase
+Firely.Fhir.Validation.TypeSpecifierCase.Condition.get -> string!
+Firely.Fhir.Validation.TypeSpecifierCase.Condition.init -> void
+Firely.Fhir.Validation.TypeSpecifierCase.Deconstruct(out string! Condition, out Firely.Fhir.Validation.Canonical! Type) -> void
+Firely.Fhir.Validation.TypeSpecifierCase.Type.get -> Firely.Fhir.Validation.Canonical!
+Firely.Fhir.Validation.TypeSpecifierCase.Type.init -> void
+Firely.Fhir.Validation.TypeSpecifierCase.TypeSpecifierCase(Firely.Fhir.Validation.TypeSpecifierCase! original) -> void
+Firely.Fhir.Validation.TypeSpecifierCase.TypeSpecifierCase(string! Condition, Firely.Fhir.Validation.Canonical! Type) -> void
+Firely.Fhir.Validation.TypeSpecifierValidator
+Firely.Fhir.Validation.TypeSpecifierValidator.Cases.get -> System.Collections.Generic.IReadOnlyList<Firely.Fhir.Validation.TypeSpecifierCase!>!
+Firely.Fhir.Validation.TypeSpecifierValidator.DefaultType.get -> Firely.Fhir.Validation.Canonical?
+Firely.Fhir.Validation.TypeSpecifierValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
+Firely.Fhir.Validation.TypeSpecifierValidator.TypeSpecifierValidator(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.TypeSpecifierCase!>! cases, Firely.Fhir.Validation.Canonical? defaultType = null) -> void
+override Firely.Fhir.Validation.TypeSpecifierCase.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.TypeSpecifierCase.GetHashCode() -> int
+override Firely.Fhir.Validation.TypeSpecifierCase.ToString() -> string!
+static Firely.Fhir.Validation.TypeSpecifierCase.operator !=(Firely.Fhir.Validation.TypeSpecifierCase? left, Firely.Fhir.Validation.TypeSpecifierCase? right) -> bool
+static Firely.Fhir.Validation.TypeSpecifierCase.operator ==(Firely.Fhir.Validation.TypeSpecifierCase? left, Firely.Fhir.Validation.TypeSpecifierCase? right) -> bool
+virtual Firely.Fhir.Validation.TypeSpecifierCase.<Clone>$() -> Firely.Fhir.Validation.TypeSpecifierCase!
+virtual Firely.Fhir.Validation.TypeSpecifierCase.EqualityContract.get -> System.Type!
+virtual Firely.Fhir.Validation.TypeSpecifierCase.Equals(Firely.Fhir.Validation.TypeSpecifierCase? other) -> bool
+virtual Firely.Fhir.Validation.TypeSpecifierCase.PrintMembers(System.Text.StringBuilder! builder) -> bool
 Firely.Fhir.Validation.ValidateBestPracticesSeverity
 Firely.Fhir.Validation.ValidateBestPracticesSeverity.Error = 1 -> Firely.Fhir.Validation.ValidateBestPracticesSeverity
 Firely.Fhir.Validation.ValidateBestPracticesSeverity.Warning = 0 -> Firely.Fhir.Validation.ValidateBestPracticesSeverity
@@ -374,8 +421,14 @@ override Firely.Fhir.Validation.FhirTypeLabelValidator.Key.get -> string!
 override Firely.Fhir.Validation.FhirTypeLabelValidator.Value.get -> object!
 override Firely.Fhir.Validation.FhirUriValidator.Key.get -> string!
 override Firely.Fhir.Validation.FhirUriValidator.Value.get -> object!
+override Firely.Fhir.Validation.IdExpectationValidator.Key.get -> string!
+override Firely.Fhir.Validation.IdExpectationValidator.Value.get -> object!
+override Firely.Fhir.Validation.ImpliedStringPrefixValidator.Key.get -> string!
+override Firely.Fhir.Validation.ImpliedStringPrefixValidator.Value.get -> object!
 override Firely.Fhir.Validation.IssueAssertion.Equals(object? obj) -> bool
 override Firely.Fhir.Validation.IssueAssertion.GetHashCode() -> int
+override Firely.Fhir.Validation.JsonNullableValidator.Key.get -> string!
+override Firely.Fhir.Validation.JsonNullableValidator.Value.get -> object!
 override Firely.Fhir.Validation.MaxLengthValidator.Key.get -> string!
 override Firely.Fhir.Validation.MaxLengthValidator.Value.get -> object!
 override Firely.Fhir.Validation.RegExValidator.Key.get -> string!

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/Firely.Fhir.Validation.Compilation.Tests.Shared.projitems
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/Firely.Fhir.Validation.Compilation.Tests.Shared.projitems
@@ -44,5 +44,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Support\FluentAssertionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestProfileArtifactSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\TypeReferenceBuilderTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SchemaBuilders\LogicalModelBuilderTests.cs" />
   </ItemGroup>
 </Project>

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
@@ -208,19 +208,6 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             members.OfType<RequiredValidator>().Should().ContainSingle().Subject.RequiredMembers;
 
         [Fact]
-        public void NullableRequiredMemberIsNotReportedAsMissing()
-        {
-            // A JSON null yields no node, so a required-but-nullable member would always be reported
-            // missing - it is left out of the RequiredValidator instead.
-            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
-                new ElementDefinition("Model"),
-                member("Model.plain", 1),
-                member("Model.nullable", 1, "1", new Extension(JSON_NULLABLE, new FhirBoolean(true))));
-
-            requiredMembersOf(convertElement(sd)).Should().BeEquivalentTo(["plain"]);
-        }
-
-        [Fact]
         public void ExplicitlyNonNullableRequiredMemberStaysRequired()
         {
             var sd = model(StructureDefinition.StructureDefinitionKind.Logical,

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
@@ -278,5 +278,91 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var malformed = uuidElement(new Extension(ID_EXPECTATION, new Code("whatever")));
             new IdExpectationBuilder().Build(navFor(malformed), ElementConversionMode.Full).Should().BeEmpty();
         }
+
+        // --- CDS Hooks examples --------------------------------------------------------------------
+
+        [Fact]
+        public void CdsHooksContextExampleBuildsTypeSpecifierValidator()
+        {
+            var contextElement = new ElementDefinition("CdsHooksRequest.context")
+            {
+                Type = { new ElementDefinition.TypeRefComponent { Code = "Element" } },
+                Extension =
+                {
+                    typeSpecifier("%resource.hook = 'order-sign'", "http://example.org/fhir/StructureDefinition/OrderSignContext")
+                }
+            };
+
+            new TypeSpecifierBuilder().Build(navFor(contextElement), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<TypeSpecifierValidator>();
+        }
+
+        [Fact]
+        public void CdsHooksHookInstanceExampleBuildsImpliedStringPrefixValidator()
+        {
+            var hookInstanceElement = new ElementDefinition("CdsHooksRequest.hookInstance")
+            {
+                Type = { new ElementDefinition.TypeRefComponent { Code = "uuid" } },
+                Extension = { new Extension(IMPLIED_STRING_PREFIX, new FhirString("urn:uuid:")) }
+            };
+
+            new ImpliedStringPrefixBuilder().Build(navFor(hookInstanceElement), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<ImpliedStringPrefixValidator>();
+        }
+
+        [Fact]
+        public void CdsHooksPrefetchItemExampleBuildsKeyedObjectWithEntryCardinality()
+        {
+            const string JSON_PROPERTY_KEY = TOOLS + "json-property-key";
+
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("CdsHooksRequest"),
+                new ElementDefinition("CdsHooksRequest.prefetch")
+                {
+                    Min = 1,
+                    Max = "1"
+                },
+                new ElementDefinition("CdsHooksRequest.prefetch.item")
+                {
+                    Min = 1,
+                    Max = "*",
+                    Extension = { new Extension(JSON_PROPERTY_KEY, new Code("key")) }
+                },
+                member("CdsHooksRequest.prefetch.item.key", 1),
+                member("CdsHooksRequest.prefetch.item.value", 1));
+
+            var members = convertElement(sd, "CdsHooksRequest.prefetch.item");
+            var keyed = members.OfType<KeyedObjectValidator>().Should().ContainSingle().Subject;
+            keyed.Min.Should().Be(1);
+            keyed.Max.Should().BeNull();
+        }
+
+        [Fact]
+        public void CdsHooksDraftOrdersExampleBuildsJsonNullableValidator()
+        {
+            var draftOrdersElement = new ElementDefinition("CdsHooksResponse.cards.suggestion.draftOrders")
+            {
+                Type = { new ElementDefinition.TypeRefComponent { Code = "string" } },
+                Extension = { new Extension(JSON_NULLABLE, new FhirBoolean(true)) }
+            };
+
+            new JsonNullableBuilder().Build(navFor(draftOrdersElement), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<JsonNullableValidator>()
+                .Which.IsNullable.Should().BeTrue();
+        }
+
+        [Fact]
+        public void CdsHooksCardIdExampleBuildsIdExpectationValidator()
+        {
+            var cardIdElement = new ElementDefinition("CdsHooksResponse.cards.id")
+            {
+                Type = { new ElementDefinition.TypeRefComponent { Code = "uuid" } },
+                Extension = { new Extension(ID_EXPECTATION, new Code("required")) }
+            };
+
+            new IdExpectationBuilder().Build(navFor(cardIdElement), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<IdExpectationValidator>()
+                .Which.Expectation.Should().Be(IdExpectation.Required);
+        }
     }
 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+using FluentAssertions;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Firely.Fhir.Validation.Compilation.Tests
+{
+    /// <summary>
+    /// Tests for the builders handling the hl7.fhir.uv.tools marker extensions used by logical models,
+    /// including the type-reference substitutions they trigger.
+    /// </summary>
+    public class LogicalModelBuilderTests : IClassFixture<SchemaBuilderFixture>
+    {
+        private const string TOOLS = "http://hl7.org/fhir/tools/StructureDefinition/";
+        private const string TYPE_SPECIFIER = TOOLS + "type-specifier";
+        private const string IMPLIED_STRING_PREFIX = TOOLS + "implied-string-prefix";
+        private const string JSON_NULLABLE = TOOLS + "json-nullable";
+        private const string ID_EXPECTATION = TOOLS + "id-expectation";
+
+        private readonly SchemaBuilderFixture _fixture;
+
+        public LogicalModelBuilderTests(SchemaBuilderFixture fixture) => _fixture = fixture;
+
+        private static ElementDefinition uuidElement(params Extension[] extensions)
+        {
+            var def = new ElementDefinition("Model.field");
+            def.Type.Add(new ElementDefinition.TypeRefComponent { Code = "uuid" });
+            def.Extension.AddRange(extensions);
+            return def;
+        }
+
+        private static ElementDefinitionNavigator navFor(ElementDefinition def)
+        {
+            var nav = new ElementDefinitionNavigator(new List<ElementDefinition> { def });
+            nav.MoveToFirstChild();
+            return nav;
+        }
+
+        private static Extension typeSpecifier(string? condition, string? type)
+        {
+            var ext = new Extension { Url = TYPE_SPECIFIER };
+            if (condition is not null) ext.Extension.Add(new Extension("condition", new FhirString(condition)));
+            if (type is not null) ext.Extension.Add(new Extension("type", new FhirUri(type)));
+            return ext;
+        }
+
+        private IEnumerable<IAssertion> buildTypeReference(ElementDefinition def) =>
+            new TypeReferenceBuilder(_fixture.ResourceResolver).Build(navFor(def), ElementConversionMode.Full);
+
+        // --- type-specifier -----------------------------------------------------------------------
+
+        [Fact]
+        public void WellFormedTypeSpecifierIsBuiltAndReplacesTheTypeReference()
+        {
+            var def = uuidElement(typeSpecifier("%resource.hook = 'order-sign'", "http://example.org/Ctx"));
+
+            var validator = new TypeSpecifierBuilder().Build(navFor(def), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<TypeSpecifierValidator>().Subject;
+
+            validator.Cases.Should().ContainSingle();
+            validator.Cases[0].Condition.Should().Be("%resource.hook = 'order-sign'");
+            validator.Cases[0].Type.Should().Be((Canonical)"http://example.org/Ctx");
+
+            // The type-specifier picks the type at runtime, so the declared type[] is not validated.
+            buildTypeReference(def).Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData(null, "http://example.org/Ctx")] // no condition
+        [InlineData("%resource.hook = 'x'", null)]   // no type
+        [InlineData(null, null)]                     // empty marker
+        public void MalformedTypeSpecifierDoesNotSilentlyDisableTypeValidation(string? condition, string? type)
+        {
+            var def = uuidElement(typeSpecifier(condition, type));
+
+            new TypeSpecifierBuilder().Build(navFor(def), ElementConversionMode.Full).Should().BeEmpty();
+
+            // No replacement assertion was built, so the declared type reference must remain in place.
+            buildTypeReference(def).Should().ContainSingle().Subject
+                .Should().BeASchemaAssertionFor(Canonical.ForCoreType("uuid"));
+        }
+
+        [Fact]
+        public void NoTypeSpecifierBuildsNothing()
+        {
+            new TypeSpecifierBuilder().Build(navFor(uuidElement()), ElementConversionMode.Full).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void TypeSpecifierIsNotBuiltForContentReferences()
+        {
+            var def = uuidElement(typeSpecifier("true", "http://example.org/Ctx"));
+            new TypeSpecifierBuilder().Build(navFor(def), ElementConversionMode.ContentReference).Should().BeEmpty();
+        }
+
+        // --- implied-string-prefix ----------------------------------------------------------------
+
+        [Fact]
+        public void ImpliedStringPrefixIsBuiltAndReplacesTheTypeReference()
+        {
+            var def = uuidElement(new Extension(IMPLIED_STRING_PREFIX, new FhirString("urn:uuid:")));
+
+            var validator = new ImpliedStringPrefixBuilder().Build(navFor(def), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<ImpliedStringPrefixValidator>().Subject;
+
+            validator.Prefix.Should().Be("urn:uuid:");
+            // The declared type's own schema is re-run against "prefix + value" by the validator itself.
+            validator.SchemaUri.Should().Be(Canonical.ForCoreType("uuid"));
+
+            buildTypeReference(def).Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("")]
+        public void MalformedImpliedStringPrefixDoesNotSilentlyDisableTypeValidation(string prefix)
+        {
+            var def = uuidElement(new Extension(IMPLIED_STRING_PREFIX, new FhirString(prefix)));
+
+            new ImpliedStringPrefixBuilder().Build(navFor(def), ElementConversionMode.Full).Should().BeEmpty();
+            buildTypeReference(def).Should().ContainSingle().Subject
+                .Should().BeASchemaAssertionFor(Canonical.ForCoreType("uuid"));
+        }
+
+        [Fact]
+        public void ImpliedStringPrefixWithoutValueDoesNotSilentlyDisableTypeValidation()
+        {
+            var def = uuidElement(new Extension { Url = IMPLIED_STRING_PREFIX });
+
+            new ImpliedStringPrefixBuilder().Build(navFor(def), ElementConversionMode.Full).Should().BeEmpty();
+            buildTypeReference(def).Should().ContainSingle().Subject
+                .Should().BeASchemaAssertionFor(Canonical.ForCoreType("uuid"));
+        }
+
+        [Fact]
+        public void NoImpliedStringPrefixBuildsNothing()
+        {
+            new ImpliedStringPrefixBuilder().Build(navFor(uuidElement()), ElementConversionMode.Full).Should().BeEmpty();
+        }
+
+        // --- json-nullable ------------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void JsonNullableIsBuilt(bool isNullable)
+        {
+            var def = uuidElement(new Extension(JSON_NULLABLE, new FhirBoolean(isNullable)));
+
+            new JsonNullableBuilder().Build(navFor(def), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<JsonNullableValidator>()
+                .Which.IsNullable.Should().Be(isNullable);
+        }
+
+        [Fact]
+        public void MalformedOrAbsentJsonNullableBuildsNothing()
+        {
+            new JsonNullableBuilder().Build(navFor(uuidElement()), ElementConversionMode.Full).Should().BeEmpty();
+
+            var malformed = uuidElement(new Extension(JSON_NULLABLE, new FhirString("yes")));
+            new JsonNullableBuilder().Build(navFor(malformed), ElementConversionMode.Full).Should().BeEmpty();
+        }
+
+        // --- json-nullable and required members ---------------------------------------------------
+
+        private static StructureDefinition model(StructureDefinition.StructureDefinitionKind kind, params ElementDefinition[] elements)
+        {
+            var sd = new StructureDefinition
+            {
+                Url = "http://example.org/Model",
+                Name = "Model",
+                Type = "http://example.org/Model",
+                Kind = kind,
+                Abstract = false,
+                Derivation = StructureDefinition.TypeDerivationRule.Specialization,
+                BaseDefinition = "http://hl7.org/fhir/StructureDefinition/Element",
+                Snapshot = new StructureDefinition.SnapshotComponent()
+            };
+            sd.Snapshot.Element.AddRange(elements);
+            return sd;
+        }
+
+        private static ElementDefinition member(string path, int min, string max = "1", params Extension[] extensions)
+        {
+            var def = new ElementDefinition(path) { Min = min, Max = max };
+            def.Type.Add(new ElementDefinition.TypeRefComponent { Code = "string" });
+            def.Extension.AddRange(extensions);
+            return def;
+        }
+
+        private List<IAssertion> convertElement(StructureDefinition sd, string? childPath = null)
+        {
+            var nav = ElementDefinitionNavigator.ForSnapshot(sd);
+            nav.MoveToFirstChild();
+            if (childPath is not null) Assert.True(nav.JumpToFirst(childPath));
+            return _fixture.Builder.ConvertElement(nav);
+        }
+
+        private static IEnumerable<string> requiredMembersOf(List<IAssertion> members) =>
+            members.OfType<RequiredValidator>().Should().ContainSingle().Subject.RequiredMembers;
+
+        [Fact]
+        public void NullableRequiredMemberIsNotReportedAsMissing()
+        {
+            // A JSON null yields no node, so a required-but-nullable member would always be reported
+            // missing - it is left out of the RequiredValidator instead.
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                member("Model.plain", 1),
+                member("Model.nullable", 1, "1", new Extension(JSON_NULLABLE, new FhirBoolean(true))));
+
+            requiredMembersOf(convertElement(sd)).Should().BeEquivalentTo(["plain"]);
+        }
+
+        [Fact]
+        public void ExplicitlyNonNullableRequiredMemberStaysRequired()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                member("Model.nonNullable", 1, "1", new Extension(JSON_NULLABLE, new FhirBoolean(false))));
+
+            requiredMembersOf(convertElement(sd)).Should().BeEquivalentTo(["nonNullable"]);
+        }
+
+        [Fact]
+        public void JsonNullableIsIgnoredOutsideLogicalModels()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.ComplexType,
+                new ElementDefinition("Model"),
+                member("Model.nullable", 1, "1", new Extension(JSON_NULLABLE, new FhirBoolean(true))));
+
+            requiredMembersOf(convertElement(sd)).Should().BeEquivalentTo(["nullable"]);
+        }
+
+        // --- json-property-key (keyed objects) ----------------------------------------------------
+
+        [Fact]
+        public void KeyedObjectCarriesTheElementsCardinalityForItsEntries()
+        {
+            const string JSON_PROPERTY_KEY = TOOLS + "json-property-key";
+
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                new ElementDefinition("Model.prefetch")
+                {
+                    Min = 1,
+                    Max = "*",
+                    Extension = { new Extension(JSON_PROPERTY_KEY, new Code("key")) }
+                },
+                member("Model.prefetch.key", 1),
+                member("Model.prefetch.value", 1));
+
+            var members = convertElement(sd, "Model.prefetch");
+
+            var keyed = members.OfType<KeyedObjectValidator>().Should().ContainSingle().Subject;
+            keyed.Min.Should().Be(1);
+            keyed.Max.Should().BeNull();
+
+            // The element is a single JSON object, so counting its occurrences would be meaningless.
+            members.OfType<CardinalityValidator>().Should().BeEmpty();
+        }
+
+        // --- id-expectation -----------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("optional", IdExpectation.Optional)]
+        [InlineData("required", IdExpectation.Required)]
+        [InlineData("prohibited", IdExpectation.Prohibited)]
+        public void IdExpectationIsBuilt(string code, IdExpectation expected)
+        {
+            var def = uuidElement(new Extension(ID_EXPECTATION, new Code(code)));
+
+            new IdExpectationBuilder().Build(navFor(def), ElementConversionMode.Full)
+                .Should().ContainSingle().Subject.Should().BeOfType<IdExpectationValidator>()
+                .Which.Expectation.Should().Be(expected);
+        }
+
+        [Fact]
+        public void MalformedOrAbsentIdExpectationBuildsNothing()
+        {
+            new IdExpectationBuilder().Build(navFor(uuidElement()), ElementConversionMode.Full).Should().BeEmpty();
+
+            var malformed = uuidElement(new Extension(ID_EXPECTATION, new Code("whatever")));
+            new IdExpectationBuilder().Build(navFor(malformed), ElementConversionMode.Full).Should().BeEmpty();
+        }
+    }
+}

--- a/test/Firely.Fhir.Validation.Tests/Impl/KeyedObjectValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/KeyedObjectValidatorTests.cs
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace Firely.Fhir.Validation.Tests
+{
+    [TestClass]
+    public class KeyedObjectValidatorTests
+    {
+        // A keyed object's entries are the flattened children of the container node - CodeableConcept
+        // with N codings and a text stands in for a JSON object with N+1 properties here.
+        private static PocoNode entries(int codings, bool withText = false) =>
+            new CodeableConcept
+            {
+                Coding = [.. Enumerable.Range(0, codings).Select(i => new Coding("http://example.org", $"c{i}"))],
+                Text = withText ? "text" : null
+            }.ToPocoNode();
+
+        private static ResultReport validate(KeyedObjectValidator sut, PocoNode input) =>
+            ((IValidatable)sut).Validate(input, ValidationSettings.BuildMinimalContext(), new ValidationState());
+
+        [TestMethod]
+        public void EntriesAreCountedAgainstCardinality()
+        {
+            var sut = new KeyedObjectValidator(ResultAssertion.SUCCESS, min: 1, max: 2);
+
+            // The container itself is a single node, so without entry counting an empty object would
+            // wrongly satisfy min=1 and a three-entry object would wrongly satisfy max=2.
+            Assert.IsFalse(validate(sut, entries(0)).IsSuccessful);
+            Assert.IsTrue(validate(sut, entries(1)).IsSuccessful);
+            Assert.IsTrue(validate(sut, entries(2)).IsSuccessful);
+            Assert.IsFalse(validate(sut, entries(2, withText: true)).IsSuccessful);
+        }
+
+        [TestMethod]
+        public void NoCardinalityMeansNoCountConstraint()
+        {
+            var sut = new KeyedObjectValidator(ResultAssertion.SUCCESS);
+
+            Assert.IsTrue(validate(sut, entries(0)).IsSuccessful);
+            Assert.IsTrue(validate(sut, entries(5)).IsSuccessful);
+        }
+
+        [TestMethod]
+        public void EveryEntryIsValidatedAgainstTheEntryAssertion()
+        {
+            var sut = new KeyedObjectValidator(new FhirTypeLabelValidator("Quantity"));
+
+            var result = validate(sut, entries(2));
+            Assert.IsFalse(result.IsSuccessful);
+            Assert.AreEqual(2, result.Evidence.Count);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(IncorrectElementDefinitionException))]
+        public void UpperCardinalityCannotBeLowerThanLower()
+        {
+            _ = new KeyedObjectValidator(ResultAssertion.SUCCESS, min: 2, max: 1);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(IncorrectElementDefinitionException))]
+        public void CardinalityCannotBeNegative()
+        {
+            _ = new KeyedObjectValidator(ResultAssertion.SUCCESS, min: -1);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces enhanced support for FHIR logical models, particularly those used in CDS Hooks and Da Vinci CRD, and adds several new schema builders to improve validation capabilities. The changes ensure correct handling of logical models' unique serialization patterns, such as property keying and named extensions, and make the schema compilation process more robust and extensible.

**Logical model and schema compilation improvements:**

* Logical models' type codes (which are canonical URLs) are now handled directly in `deriveSystemTypeFromXsdType`, avoiding incorrect wrapping as core FHIR types.
* Logical models are no longer assigned a FHIR type label, preventing silent validation failures due to type mismatches.
* Logical models are instantiated as `LogicalModelSchema` and unresolvable logical model bases are now tolerated (rather than causing compilation errors), improving compatibility with real-world logical model hierarchies. [[1]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcR110-R120) [[2]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcL124-R136)
* The schema compilation logic (`SchemaBuilder.cs`) has been extended to correctly handle logical models' special serialization cases:
  - Elements keyed by a sibling child's value (json-property-key) are now validated as keyed objects.
  - Named extension carriers are detected and handled, allowing additional children with runtime validation against their defining StructureDefinitions.
  - Logical models' children are keyed by their JSON property name, supporting custom JSON naming. [[1]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcL195-R226) [[2]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcR236-R248) [[3]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcL295-R343) [[4]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcL320-R424) [[5]](diffhunk://#diff-70ddbca84a60e4c5e791533d3664bde5a213254e27bae8da74e5c881f76dcdfcL367-R446)

**New schema builders:**

* Added `IdExpectationBuilder`, `ImpliedStringPrefixBuilder`, and `JsonNullableBuilder` to support new FHIR tooling extensions for id expectations, implied string prefixes, and JSON nullability, respectively. [[1]](diffhunk://#diff-52226f68ba65958bbdb9cee5df11a11c461b5b9606b607c30082344795a41cd6R1-R46) [[2]](diffhunk://#diff-36b1b868920d6ec91f3c2f2fa7f272fe19cdafaa7f5059f43ee73f7041ddf891R1-R43) [[3]](diffhunk://#diff-6db4c9263a171dd6e5dbc36c28349e11c305e4bcb3bf2b96dd1dd48a9cb29667R1-R36)
* Updated the project file to include the new schema builder files and supporting extensions. [[1]](diffhunk://#diff-5c438725a7931a5e522edbe886291ec197684ca328d49f2bb64017a8823db3abR47-R49) [[2]](diffhunk://#diff-5c438725a7931a5e522edbe886291ec197684ca328d49f2bb64017a8823db3abR62-R63)

These changes significantly improve the flexibility and correctness of FHIR logical model validation and extend the schema system to support new FHIR extension patterns.