### PR TITLE
Advisor groundwork phase 2: binding checks, native reference target dispatch, invariant severity override

### DIFF
--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
@@ -236,9 +236,9 @@ namespace Firely.Fhir.Validation.Compilation
                 is { } notnullAgg && notnullAgg.Any() ? notnullAgg : null;
 
             var convertedVer = (ReferenceVersionRules?)ver;
-            return targetCases.Count > 0
-                ? new ReferencedInstanceValidator(targetCases, convertedAgg, convertedVer)
-                : new ReferencedInstanceValidator(ResultAssertion.SUCCESS, convertedAgg, convertedVer);
+
+            // targetCases is never empty: references without target profiles get a "Resource" case.
+            return new ReferencedInstanceValidator(targetCases, convertedAgg, convertedVer);
         }
 
         private const string EXPECTEDPROFILES = "%EXPECTEDPROFILES%";
@@ -258,22 +258,17 @@ namespace Firely.Fhir.Validation.Compilation
         }
 
 
-        private record TypeChoice(string TypeLabel, string Canonical);
-
         // Groups the target profiles by the type they constrain, and builds a target case per type:
         // the explicit representation of "the target must be one of these types, and is then validated
         // against the profiles for that type" that the ReferencedInstanceValidator dispatches on.
         public IReadOnlyList<ReferencedInstanceValidator.TargetCase> ConvertTargetProfilesToTargetCases(IEnumerable<string> targetProfiles)
         {
-            var typecases = targetProfiles
-                .Select(p => new TypeChoice(fetchSd(p).Type ?? throw new InvalidOperationException($"Structure definition {p} does not have a type set"), p))
-                .GroupBy(pp => pp.TypeLabel);
-
             var failureMessage = $"Referenced resource '{IssueAssertion.Pattern.RESOURCEURL}' does not validate against any of the expected target profiles ({EXPECTEDPROFILES}).";
 
-            return typecases
+            return targetProfiles
+                .GroupBy(p => fetchSd(p).Type ?? throw new InvalidOperationException($"Structure definition {p} does not have a type set"))
                 .Select(c => new ReferencedInstanceValidator.TargetCase(c.Key,
-                    ConvertProfilesToSchemaReferences(c.Select(g => g.Canonical).ToList(), failureMessage)))
+                    ConvertProfilesToSchemaReferences(c.ToList(), failureMessage)))
                 .ToList();
 
             StructureDefinition fetchSd(string canonical)

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
@@ -176,9 +176,9 @@ namespace Firely.Fhir.Validation.Compilation
                 // the targetProfiles mentioned in the typeref. If there are no target profiles, then the only thing
                 // we can validate against is the runtime type of the referenced resource.
                 var targetProfiles = !typeRef.TargetProfile.Any() ? new[] { Canonical.ForCoreType("Resource").ToString() } : typeRef.TargetProfile;
-                var targetProfileAssertions = ConvertTargetProfilesToSchemaReferences(targetProfiles);
+                var targetCases = ConvertTargetProfilesToTargetCases(targetProfiles);
 
-                var validateReferenceAssertion = buildvalidateInstance(typeRef.AggregationElement, typeRef.Versioning, targetProfileAssertions);
+                var validateReferenceAssertion = buildvalidateInstance(typeRef.AggregationElement, typeRef.Versioning, targetCases);
                 return profileAssertions is not null
                     ? new AllValidator(profileAssertions, validateReferenceAssertion)
                     : validateReferenceAssertion;
@@ -221,11 +221,11 @@ namespace Firely.Fhir.Validation.Compilation
 
         /// <summary>
         /// Builds the validator that fetches a referenced resource from the runtime-supplied reference,
-        /// and validates it against a targetschema + additional aggregation/versioning rules.
+        /// and validates it against the target cases + additional aggregation/versioning rules.
         /// </summary>
         private static IAssertion buildvalidateInstance(IEnumerable<Code<ElementDefinition.AggregationMode>> agg,
                            ElementDefinition.ReferenceVersionRules? ver,
-                           IAssertion targetSchema)
+                           IReadOnlyList<ReferencedInstanceValidator.TargetCase> targetCases)
         {
             // Convert the enum, skip nulls and make sure we use null as the
             // argument to the constructor if the collection is empty.
@@ -236,7 +236,9 @@ namespace Firely.Fhir.Validation.Compilation
                 is { } notnullAgg && notnullAgg.Any() ? notnullAgg : null;
 
             var convertedVer = (ReferenceVersionRules?)ver;
-            return new ReferencedInstanceValidator(targetSchema, convertedAgg, convertedVer);
+            return targetCases.Count > 0
+                ? new ReferencedInstanceValidator(targetCases, convertedAgg, convertedVer)
+                : new ReferencedInstanceValidator(ResultAssertion.SUCCESS, convertedAgg, convertedVer);
         }
 
         private const string EXPECTEDPROFILES = "%EXPECTEDPROFILES%";
@@ -258,14 +260,21 @@ namespace Firely.Fhir.Validation.Compilation
 
         private record TypeChoice(string TypeLabel, string Canonical);
 
-        public IAssertion ConvertTargetProfilesToSchemaReferences(IEnumerable<string> targetProfiles)
+        // Groups the target profiles by the type they constrain, and builds a target case per type:
+        // the explicit representation of "the target must be one of these types, and is then validated
+        // against the profiles for that type" that the ReferencedInstanceValidator dispatches on.
+        public IReadOnlyList<ReferencedInstanceValidator.TargetCase> ConvertTargetProfilesToTargetCases(IEnumerable<string> targetProfiles)
         {
             var typecases = targetProfiles
                 .Select(p => new TypeChoice(fetchSd(p).Type ?? throw new InvalidOperationException($"Structure definition {p} does not have a type set"), p))
-                .GroupBy(pp => pp.TypeLabel)
-                .ToList();
+                .GroupBy(pp => pp.TypeLabel);
 
-            return buildLabelledChoice(typecases);
+            var failureMessage = $"Referenced resource '{IssueAssertion.Pattern.RESOURCEURL}' does not validate against any of the expected target profiles ({EXPECTEDPROFILES}).";
+
+            return typecases
+                .Select(c => new ReferencedInstanceValidator.TargetCase(c.Key,
+                    ConvertProfilesToSchemaReferences(c.Select(g => g.Canonical).ToList(), failureMessage)))
+                .ToList();
 
             StructureDefinition fetchSd(string canonical)
             {
@@ -275,40 +284,6 @@ namespace Firely.Fhir.Validation.Compilation
         }
 
         private static string replacep(string pattern, IEnumerable<string>? profiles) => pattern.Replace(EXPECTEDPROFILES, string.Join(", ", profiles ?? Enumerable.Empty<string>()));
-
-        // This method creates a slicing on the instance type, where each case will then try to validate
-        // on each of the profiles in the list based on that instance type.
-        private static IAssertion buildLabelledChoice(List<IGrouping<string, TypeChoice>> cases)
-        {
-            // special case 1, no cases, direct success.
-            if (!cases.Any()) return ResultAssertion.SUCCESS;
-
-            var failureMessageA = $"Referenced resource '{IssueAssertion.Pattern.RESOURCEURL}' does not validate against any of the expected target profiles ({EXPECTEDPROFILES}).";
-
-            // special case 2, only one possible case, no need to build a nested
-            // discriminatorless slicer to validate possible options         
-            if (cases.Count == 1)
-            {
-                var profiles = cases.Single().Select(s => s.Canonical).ToList();
-                return ConvertProfilesToSchemaReferences(profiles, failureMessageA);
-            }
-
-            // case 3 - more than one type, we need to slice on type first.
-            var sliceCases = cases.Select(c => buildTypeSelectorSlice(c, failureMessageA));
-
-            var types = string.Join(", ", cases.Select(c => c.Key));
-            var failureMessageB = $"{failureMessageA} None of these are profiles on type {IssueAssertion.Pattern.INSTANCETYPE} of the resource.";
-
-
-            return new SliceValidator(ordered: false, defaultAtEnd: false, @default: createFailure(failureMessageB, cases.SelectMany(c => c.Select(c => c.Canonical))), sliceCases);
-
-            static SliceValidator.SliceCase buildTypeSelectorSlice(IGrouping<string, TypeChoice> group, string failureMessage)
-            {
-                // The slice uses the fhir type label (in the key of the group here) as discriminator.
-                var typeSelector = new FhirTypeLabelValidator(group.Key);
-                return new SliceValidator.SliceCase("for" + group.Key, typeSelector, ConvertProfilesToSchemaReferences(group.Select(g => g.Canonical).ToList(), failureMessage));
-            }
-        }
 
 
         // TODO: there are actually two issues: one for an invalid choice, and one for a reference with an invalid targetProfile

--- a/src/Firely.Fhir.Validation/Firely.Fhir.Validation.csproj
+++ b/src/Firely.Fhir.Validation/Firely.Fhir.Validation.csproj
@@ -9,6 +9,12 @@
 		<AssemblyName>Firely.Fhir.Validation</AssemblyName>
 	</PropertyGroup>
 
+	<!-- The record hierarchy of InvariantValidator generates covariant Clone methods on net8.0 but not
+	     on netstandard2.1, so those members are declared in target-framework-specific API files. -->
+	<ItemGroup Condition="Exists('$(MSBuildProjectDirectory)\PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt')">
+		<AdditionalFiles Include="PublicAPI\$(TargetFramework)\PublicAPI.Unshipped.txt" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="MessagePack.Annotations" Version="3.1.8" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -38,9 +38,10 @@ namespace Firely.Fhir.Validation
         None = 0,
 
         /// <summary>
-        /// Check that the concepts are valid, i.e. that the instance's code(s) are in the bound value set
-        /// (via the terminology service). When this check is disabled, no terminology call is made at all,
-        /// which also disables the <see cref="Displays"/> check.
+        /// Check that the concepts are valid: that the instance carries the coded content its
+        /// binding strength requires, and that the code(s) are in the bound value set (via the
+        /// terminology service). When this check is disabled, the coded content is not checked
+        /// at all - no terminology call is made, which also disables the <see cref="Displays"/> check.
         /// </summary>
         Concepts = 1,
 
@@ -234,23 +235,21 @@ namespace Firely.Fhir.Validation
         private static bool codeableConceptHasCode(CodeableConcept cc) =>
             cc.Coding.Any(cd => !string.IsNullOrEmpty(cd.Code));
 
-        // When display validation is disabled, the displays are omitted from the terminology
-        // call, so the service has nothing to check them against (per the $validate-code
-        // operation: "If no display is provided, the server cannot validate the display value").
-        private Coding withDisplayCheck(Coding cd)
+        /// <summary>
+        /// Returns a copy of the coding without its display, leaving the instance untouched.
+        /// </summary>
+        private static Coding stripDisplay(Coding cd)
         {
-            if (Checks.HasFlag(CodedContentChecks.Displays)) return cd;
-
             var stripped = (Coding)cd.DeepCopy();
             stripped.DisplayElement = null;
             return stripped;
         }
 
-        /// <inheritdoc cref="withDisplayCheck(Coding)"/>
-        private CodeableConcept withDisplayCheck(CodeableConcept cc)
+        /// <summary>
+        /// Returns a copy of the concept without the displays on its codings, leaving the instance untouched.
+        /// </summary>
+        private static CodeableConcept stripDisplays(CodeableConcept cc)
         {
-            if (Checks.HasFlag(CodedContentChecks.Displays)) return cc;
-
             var stripped = (CodeableConcept)cc.DeepCopy();
             foreach (var coding in stripped.Coding)
                 coding.DisplayElement = null;
@@ -280,8 +279,11 @@ namespace Firely.Fhir.Validation
                     FhirString str => vcp.WithCode(str.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     FhirUri uri => vcp.WithCode(uri.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     Code co => vcp.WithCode(co.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: true),
-                    Coding cd => vcp.WithCoding(withDisplayCheck(cd)),
-                    CodeableConcept cc => vcp.WithCodeableConcept(withDisplayCheck(cc)),
+                    // When display validation is disabled, the displays are omitted from the terminology
+                    // call, so the service has nothing to check them against (per the $validate-code
+                    // operation: "If no display is provided, the server cannot validate the display value").
+                    Coding cd => vcp.WithCoding(Checks.HasFlag(CodedContentChecks.Displays) ? cd : stripDisplay(cd)),
+                    CodeableConcept cc => vcp.WithCodeableConcept(Checks.HasFlag(CodedContentChecks.Displays) ? cc : stripDisplays(cc)),
                     _ => throw Error.InvalidOperation($"Parsed bindable was of unexpected instance type '{bindable.TypeName}'.")
                 };
             }

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -236,20 +236,28 @@ namespace Firely.Fhir.Validation
             cc.Coding.Any(cd => !string.IsNullOrEmpty(cd.Code));
 
         /// <summary>
-        /// Returns a copy of the coding without its display, leaving the instance untouched.
+        /// Returns the coding as-is when display checking is enabled; otherwise a copy without
+        /// its display (leaving the instance untouched), so the terminology call has nothing to
+        /// check the display against (per the $validate-code operation: "If no display is
+        /// provided, the server cannot validate the display value").
         /// </summary>
-        private static Coding stripDisplay(Coding cd)
+        private Coding withDisplayCheck(Coding cd)
         {
+            if (Checks.HasFlag(CodedContentChecks.Displays)) return cd;
+
             var stripped = (Coding)cd.DeepCopy();
             stripped.DisplayElement = null;
             return stripped;
         }
 
         /// <summary>
-        /// Returns a copy of the concept without the displays on its codings, leaving the instance untouched.
+        /// Returns the concept as-is when display checking is enabled; otherwise a copy without
+        /// the displays on its codings (leaving the instance untouched). See <see cref="withDisplayCheck(Coding)"/>.
         /// </summary>
-        private static CodeableConcept stripDisplays(CodeableConcept cc)
+        private CodeableConcept withDisplayCheck(CodeableConcept cc)
         {
+            if (Checks.HasFlag(CodedContentChecks.Displays)) return cc;
+
             var stripped = (CodeableConcept)cc.DeepCopy();
             foreach (var coding in stripped.Coding)
                 coding.DisplayElement = null;
@@ -279,11 +287,8 @@ namespace Firely.Fhir.Validation
                     FhirString str => vcp.WithCode(str.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     FhirUri uri => vcp.WithCode(uri.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     Code co => vcp.WithCode(co.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: true),
-                    // When display validation is disabled, the displays are omitted from the terminology
-                    // call, so the service has nothing to check them against (per the $validate-code
-                    // operation: "If no display is provided, the server cannot validate the display value").
-                    Coding cd => vcp.WithCoding(Checks.HasFlag(CodedContentChecks.Displays) ? cd : stripDisplay(cd)),
-                    CodeableConcept cc => vcp.WithCodeableConcept(Checks.HasFlag(CodedContentChecks.Displays) ? cc : stripDisplays(cc)),
+                    Coding cd => vcp.WithCoding(withDisplayCheck(cd)),
+                    CodeableConcept cc => vcp.WithCodeableConcept(withDisplayCheck(cc)),
                     _ => throw Error.InvalidOperation($"Parsed bindable was of unexpected instance type '{bindable.TypeName}'.")
                 };
             }

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -22,6 +22,49 @@ using System.Runtime.Serialization;
 namespace Firely.Fhir.Validation
 {
     /// <summary>
+    /// The aspects of the coded content that a <see cref="BindingValidator"/> checks.
+    /// </summary>
+    [Flags]
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public enum CodedContentChecks
+    {
+        /// <summary>
+        /// Check nothing about the coded content.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Check that the concepts are valid, i.e. that the instance's code(s) are in the bound value set
+        /// (via the terminology service). When this check is disabled, no terminology call is made at all,
+        /// which also disables the <see cref="Displays"/> check.
+        /// </summary>
+        Concepts = 1,
+
+        /// <summary>
+        /// Check that the displays accompanying the code(s) are valid for those codes. This check rides
+        /// the same terminology call as <see cref="Concepts"/>: when disabled, the display texts are
+        /// omitted from the call, so the terminology service cannot (and will not) validate them.
+        /// </summary>
+        Displays = 2,
+
+        /// <summary>
+        /// Check the status of the applicable value sets and code systems. NOTE: this check cannot be
+        /// implemented with the current terminology service interface and is accepted only so that
+        /// configurations mentioning it can round-trip.
+        /// </summary>
+        Status = 4,
+
+        /// <summary>
+        /// The default set of checks, matching the validator's standard behavior.
+        /// </summary>
+        Default = Concepts | Displays
+    }
+
+    /// <summary>
     /// An assertion that expresses terminology binding requirements for a coded element.
     /// </summary>
     [DataContract]
@@ -86,6 +129,12 @@ namespace Firely.Fhir.Validation
         [DataMember]
         public bool AbstractAllowed { get; private set; }
 
+        /// <summary>
+        /// The aspects of the coded content this validator checks. Defaults to
+        /// <see cref="CodedContentChecks.Default"/>, the validator's standard behavior.
+        /// </summary>
+        [DataMember]
+        public CodedContentChecks Checks { get; private set; }
 
         /// <summary>
         /// Constructs a validator for validating a coded element.
@@ -94,10 +143,25 @@ namespace Firely.Fhir.Validation
         /// <param name="strength">Indicates the degree of conformance expectations associated with this binding</param>
         /// <param name="abstractAllowed"></param>
         public BindingValidator(Canonical valueSetUri, BindingStrength? strength, bool abstractAllowed = true)
+            : this(valueSetUri, strength, abstractAllowed, CodedContentChecks.Default)
+        {
+            // nothing
+        }
+
+        /// <summary>
+        /// Constructs a validator for validating a coded element, checking only the given aspects
+        /// of the coded content.
+        /// </summary>
+        /// <param name="valueSetUri">Value set Canonical URL</param>
+        /// <param name="strength">Indicates the degree of conformance expectations associated with this binding</param>
+        /// <param name="abstractAllowed">Whether abstract codes may be used in an instance</param>
+        /// <param name="checks">The aspects of the coded content to check</param>
+        public BindingValidator(Canonical valueSetUri, BindingStrength? strength, bool abstractAllowed, CodedContentChecks checks)
         {
             ValueSetUri = valueSetUri;
             Strength = strength;
             AbstractAllowed = abstractAllowed;
+            Checks = checks;
         }
 
         /// <inheritdoc />
@@ -117,7 +181,16 @@ namespace Firely.Fhir.Validation
                     new TraceAssertion(input.GetLocation(),
                         $"Validation of binding with non-bindable instance type '{input.Poco.TypeName}' always succeeds."));
             }
-            
+
+            // When concept validation is disabled, no coded content is checked at all - this also
+            // saves the (expensive) call to the terminology service.
+            if (!Checks.HasFlag(CodedContentChecks.Concepts))
+            {
+                return vc.TraceResult(() =>
+                    new TraceAssertion(input.GetLocation(),
+                        $"Validation of the coded content against valueset '{ValueSetUri}' is disabled for this binding."));
+            }
+
             if (input.ParseBindable() is DataType bindable)
             {
                 var result = verifyContentRequirements(input, bindable, s);
@@ -161,6 +234,29 @@ namespace Firely.Fhir.Validation
         private static bool codeableConceptHasCode(CodeableConcept cc) =>
             cc.Coding.Any(cd => !string.IsNullOrEmpty(cd.Code));
 
+        // When display validation is disabled, the displays are omitted from the terminology
+        // call, so the service has nothing to check them against (per the $validate-code
+        // operation: "If no display is provided, the server cannot validate the display value").
+        private Coding withDisplayCheck(Coding cd)
+        {
+            if (Checks.HasFlag(CodedContentChecks.Displays)) return cd;
+
+            var stripped = (Coding)cd.DeepCopy();
+            stripped.DisplayElement = null;
+            return stripped;
+        }
+
+        /// <inheritdoc cref="withDisplayCheck(Coding)"/>
+        private CodeableConcept withDisplayCheck(CodeableConcept cc)
+        {
+            if (Checks.HasFlag(CodedContentChecks.Displays)) return cc;
+
+            var stripped = (CodeableConcept)cc.DeepCopy();
+            foreach (var coding in stripped.Coding)
+                coding.DisplayElement = null;
+            return stripped;
+        }
+
 
         private ResultReport validateCode(Element bindable, ValidationSettings vc, ValidationState s, PocoNode input)
         {
@@ -184,8 +280,8 @@ namespace Firely.Fhir.Validation
                     FhirString str => vcp.WithCode(str.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     FhirUri uri => vcp.WithCode(uri.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: false),
                     Code co => vcp.WithCode(co.Value, system: null, display: null, systemVersion: null, displayLanguage: null, context: null, inferSystem: true),
-                    Coding cd => vcp.WithCoding(cd),
-                    CodeableConcept cc => vcp.WithCodeableConcept(cc),
+                    Coding cd => vcp.WithCoding(withDisplayCheck(cd)),
+                    CodeableConcept cc => vcp.WithCodeableConcept(withDisplayCheck(cc)),
                     _ => throw Error.InvalidOperation($"Parsed bindable was of unexpected instance type '{bindable.TypeName}'.")
                 };
             }
@@ -231,6 +327,9 @@ namespace Firely.Fhir.Validation
                 props.Add(new JProperty("strength", Strength!.GetLiteral()));
 
             props.Add(new JProperty("valueSet", (string)ValueSetUri));
+
+            if (Checks != CodedContentChecks.Default)
+                props.Add(new JProperty("checks", Checks.ToString()));
 
             return new JProperty("binding", props);
         }

--- a/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/BindingValidator.cs
@@ -135,7 +135,7 @@ namespace Firely.Fhir.Validation
         /// <see cref="CodedContentChecks.Default"/>, the validator's standard behavior.
         /// </summary>
         [DataMember]
-        public CodedContentChecks Checks { get; private set; }
+        public CodedContentChecks Checks { get; private set; } = CodedContentChecks.Default;
 
         /// <summary>
         /// Constructs a validator for validating a coded element.
@@ -143,7 +143,9 @@ namespace Firely.Fhir.Validation
         /// <param name="valueSetUri">Value set Canonical URL</param>
         /// <param name="strength">Indicates the degree of conformance expectations associated with this binding</param>
         /// <param name="abstractAllowed"></param>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         public BindingValidator(Canonical valueSetUri, BindingStrength? strength, bool abstractAllowed = true)
+#pragma warning restore RS0026
             : this(valueSetUri, strength, abstractAllowed, CodedContentChecks.Default)
         {
             // nothing
@@ -157,7 +159,9 @@ namespace Firely.Fhir.Validation
         /// <param name="strength">Indicates the degree of conformance expectations associated with this binding</param>
         /// <param name="abstractAllowed">Whether abstract codes may be used in an instance</param>
         /// <param name="checks">The aspects of the coded content to check</param>
-        public BindingValidator(Canonical valueSetUri, BindingStrength? strength, bool abstractAllowed, CodedContentChecks checks)
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        public BindingValidator(Canonical valueSetUri, BindingStrength? strength, bool abstractAllowed, CodedContentChecks checks = CodedContentChecks.Default)
+#pragma warning restore RS0026
         {
             ValueSetUri = valueSetUri;
             Strength = strength;

--- a/src/Firely.Fhir.Validation/Impl/ExtensionContextValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ExtensionContextValidator.cs
@@ -129,18 +129,14 @@ public class ExtensionContextValidator : IValidatable
 
         var root = instance;
         while (root.Parent is not null) root = root.Parent;
-        
-        // We need model inspector to validate the type membership, and later on choice type matches
-        // We introduced ValidationSettings.ModelInspector to be able to express it properly,
-        // but for legacy call sites we fall back to obsoleted ForType to retrieve appropriate ModelInspector
-        // for the Poco itself. That might end up being ModelInspector.Base for Bundle, or custom types
-        // That might break on a very specific case: Signature.who: choice in STU3, plain Reference in R4+
-        // and it being referenced by Bundle. That bug is expressed in the unit test
+
+        // We need the model inspector to validate the type membership, and later on choice type matches.
+        // The fallback strategy (in GetModelInspector) might end up on ModelInspector.Base for Bundle, or
+        // custom types. That might break on a very specific case: Signature.who: choice in STU3, plain
+        // Reference in R4+ and it being referenced by Bundle. That bug is expressed in the unit test
         // ExtensionContext_OnSignatureWho_DoesNotTreatAsChoiceInR4 where commented entries exhibit wrong behavior
         // of matching who[x] in R4+ despite it no longer being choice type because no ModelInspector is set in the settings
-#pragma warning disable CS0618
-        var modelInspector = vc.ModelInspector ?? ModelInspector.ForType(root.Poco.GetType());
-#pragma warning restore CS0618
+        var modelInspector = vc.GetModelInspector(root);
 
         // a single-segment expression may name a (possibly abstract) base type of the element itself,
         // e.g. "BackboneElement" should match an element of type "Patient.contact"

--- a/src/Firely.Fhir.Validation/Impl/FhirEle1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirEle1Validator.cs
@@ -56,11 +56,6 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson()
-        {
-            var props = new JObject();
-            addSeverityOverride(props);
-            return new JProperty("FastInvariant-ele1", props);
-        }
+        public override JToken ToJson() => toInvariantJson("FastInvariant-ele1");
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirEle1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirEle1Validator.cs
@@ -25,7 +25,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public class FhirEle1Validator : InvariantValidator
+    public record FhirEle1Validator : InvariantValidator
     {
         /// <inheritdoc/>
         public override string Key => "ele-1";
@@ -56,6 +56,11 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson() => new JProperty("FastInvariant-ele1", new JObject());
+        public override JToken ToJson()
+        {
+            var props = new JObject();
+            addSeverityOverride(props);
+            return new JProperty("FastInvariant-ele1", props);
+        }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirExt1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirExt1Validator.cs
@@ -58,11 +58,6 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson()
-        {
-            var props = new JObject();
-            addSeverityOverride(props);
-            return new JProperty("FastInvariant-ext1", props);
-        }
+        public override JToken ToJson() => toInvariantJson("FastInvariant-ext1");
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirExt1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirExt1Validator.cs
@@ -24,7 +24,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public class FhirExt1Validator : InvariantValidator
+    public record FhirExt1Validator : InvariantValidator
     {
         /// <inheritdoc/>
         public override string Key => "ext-1";
@@ -58,6 +58,11 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson() => new JProperty("FastInvariant-ext1", new JObject());
+        public override JToken ToJson()
+        {
+            var props = new JObject();
+            addSeverityOverride(props);
+            return new JProperty("FastInvariant-ext1", props);
+        }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
@@ -100,8 +100,7 @@ namespace Firely.Fhir.Validation
                     );
             if (HumanDescription != null)
                 props.Add(new JProperty("humanDescription", HumanDescription));
-            addSeverityOverride(props);
-            return new JProperty($"fhirPath-{Key}", props);
+            return toInvariantJson($"fhirPath-{Key}", props);
         }
 
         /// <inheritdoc/>

--- a/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
@@ -71,6 +71,21 @@ namespace Firely.Fhir.Validation
         private FhirPathCompiler? _lastUsedCompiler;
 
         /// <summary>
+        /// Value equality over the invariant's definition. Declared explicitly (instead of the
+        /// record-synthesized version) to keep the mutable compilation cache fields above out of
+        /// the comparison: equality and hash code must not change when the expression gets compiled
+        /// during validation.
+        /// </summary>
+        public virtual bool Equals(FhirPathValidator? other) =>
+            base.Equals(other) && Key == other!.Key && Expression == other.Expression &&
+            HumanDescription == other.HumanDescription && Severity == other.Severity &&
+            BestPractice == other.BestPractice;
+
+        /// <inheritdoc cref="Equals(FhirPathValidator)"/>
+        public override int GetHashCode() =>
+            HashCode.Combine(base.GetHashCode(), Key, Expression, HumanDescription, Severity, BestPractice);
+
+        /// <summary>
         /// Initializes a FhirPathValidator instance with the given FhirPath expression and identifying key.
         /// </summary>
         public FhirPathValidator(string key, string expression) : this(key, expression, null, severity: IssueSeverity.Error) { }

--- a/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirPathValidator.cs
@@ -35,7 +35,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public class FhirPathValidator : InvariantValidator
+    public record FhirPathValidator : InvariantValidator
     {
         /// <inheritdoc />
         [DataMember]
@@ -100,6 +100,7 @@ namespace Firely.Fhir.Validation
                     );
             if (HumanDescription != null)
                 props.Add(new JProperty("humanDescription", HumanDescription));
+            addSeverityOverride(props);
             return new JProperty($"fhirPath-{Key}", props);
         }
 

--- a/src/Firely.Fhir.Validation/Impl/FhirTxt1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirTxt1Validator.cs
@@ -26,7 +26,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public class FhirTxt1Validator : InvariantValidator
+    public record FhirTxt1Validator : InvariantValidator
     {
         /// <inheritdoc/>
         public override string Key => "txt-1";
@@ -70,6 +70,11 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson() => new JProperty("FastInvariant-txt1", new JObject());
+        public override JToken ToJson()
+        {
+            var props = new JObject();
+            addSeverityOverride(props);
+            return new JProperty("FastInvariant-txt1", props);
+        }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirTxt1Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirTxt1Validator.cs
@@ -70,11 +70,6 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson()
-        {
-            var props = new JObject();
-            addSeverityOverride(props);
-            return new JProperty("FastInvariant-txt1", props);
-        }
+        public override JToken ToJson() => toInvariantJson("FastInvariant-txt1");
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirTxt2Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirTxt2Validator.cs
@@ -24,7 +24,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public class FhirTxt2Validator : InvariantValidator
+    public record FhirTxt2Validator : InvariantValidator
     {
         /// <inheritdoc/>
         public override string Key => "txt-2";
@@ -46,6 +46,11 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson() => new JProperty("FastInvariant-txt2", new JObject());
+        public override JToken ToJson()
+        {
+            var props = new JObject();
+            addSeverityOverride(props);
+            return new JProperty("FastInvariant-txt2", props);
+        }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/FhirTxt2Validator.cs
+++ b/src/Firely.Fhir.Validation/Impl/FhirTxt2Validator.cs
@@ -46,11 +46,6 @@ namespace Firely.Fhir.Validation
         }
 
         /// <inheritdoc/>
-        public override JToken ToJson()
-        {
-            var props = new JObject();
-            addSeverityOverride(props);
-            return new JProperty("FastInvariant-txt2", props);
-        }
+        public override JToken ToJson() => toInvariantJson("FastInvariant-txt2");
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/InvariantValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/InvariantValidator.cs
@@ -112,13 +112,18 @@ namespace Firely.Fhir.Validation
         }
 
         /// <summary>
-        /// Adds the <see cref="SeverityOverride"/> (when set) to the given ToJson properties, so
-        /// overridden invariants are recognizable in a rendered schema.
+        /// Builds the ToJson representation of an invariant: the given properties (an empty set
+        /// when omitted) under the given name, extended with the <see cref="SeverityOverride"/>
+        /// when one is set - so overridden invariants are recognizable in a rendered schema.
         /// </summary>
-        private protected void addSeverityOverride(JObject props)
+        private protected JProperty toInvariantJson(string name, JObject? props = null)
         {
+            props ??= new JObject();
+
             if (SeverityOverride is { } so)
                 props.Add(new JProperty("severityOverride", so.GetLiteral()));
+
+            return new JProperty(name, props);
         }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/InvariantValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/InvariantValidator.cs
@@ -9,6 +9,7 @@
 using Hl7.Fhir.ElementModel;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Support;
+using Hl7.Fhir.Utility;
 using Newtonsoft.Json.Linq;
 using System;
 using System.ComponentModel;
@@ -27,7 +28,7 @@ namespace Firely.Fhir.Validation
 #else
     [System.Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
 #endif
-    public abstract class InvariantValidator : IValidatable
+    public abstract record InvariantValidator : IValidatable
     {
         /// <summary>
         /// The shorthand code identifying the invariant, as defined in the StructureDefinition.
@@ -43,7 +44,7 @@ namespace Firely.Fhir.Validation
         /// Whether failure to meet the invariant is considered an error or not.
         /// </summary>
         /// <remarks>When the severity is anything else than <see cref="IssueSeverity.Error"/>, the
-        /// <see cref="ResultReport"/> returned on failure to meet the invariant will be a 
+        /// <see cref="ResultReport"/> returned on failure to meet the invariant will be a
         /// <see cref="ValidationResult.Success"/>,
         /// and have an <see cref="IssueAssertion"/> evidence with severity level <see cref="IssueSeverity.Warning"/>.
         /// </remarks>
@@ -55,6 +56,16 @@ namespace Firely.Fhir.Validation
         /// <remarks>When this constraint is a "best practice", the outcome of validation is determined
         /// by the value of <see cref="ValidationSettings.ConstraintBestPractices"/>.</remarks>
         public abstract bool BestPractice { get; }
+
+        /// <summary>
+        /// When set, replaces the invariant's effective severity when reporting failures, taking
+        /// precedence over both the declared <see cref="Severity"/> and the
+        /// <see cref="ValidationSettings.ConstraintBestPractices"/> mapping for best-practice
+        /// invariants. Since this is an init-only property on the (record) base, a copy of any
+        /// invariant with an override can be made using a <c>with</c> expression.
+        /// </summary>
+        [DataMember]
+        public IssueSeverity? SeverityOverride { get; init; }
 
         ///<inheritdoc cref="IJsonSerializable.ToJson"/>
         public abstract JToken ToJson();
@@ -75,14 +86,16 @@ namespace Firely.Fhir.Validation
 
             if (!result.Success)
             {
-                var sev = BestPractice
+                // The effective severity: an explicit override wins over both the best-practice
+                // mapping and the invariant's declared severity.
+                var sev = SeverityOverride ?? (BestPractice
                     ? vc.ConstraintBestPractices switch
                     {
                         ValidateBestPracticesSeverity.Error => (IssueSeverity?)IssueSeverity.Error,
                         ValidateBestPracticesSeverity.Warning => (IssueSeverity?)IssueSeverity.Warning,
                         _ => throw new InvalidOperationException($"Unknown value for enum {nameof(ValidateBestPracticesSeverity)}."),
                     }
-                    : Severity;
+                    : Severity);
 
                 return new IssueAssertion(sev == IssueSeverity.Error ?
                         Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT :
@@ -96,6 +109,16 @@ namespace Firely.Fhir.Validation
             string getDescription() => Key +
                 (!string.IsNullOrEmpty(HumanDescription) ? $" \"{HumanDescription}\"" : null);
 
+        }
+
+        /// <summary>
+        /// Adds the <see cref="SeverityOverride"/> (when set) to the given ToJson properties, so
+        /// overridden invariants are recognizable in a rendered schema.
+        /// </summary>
+        private protected void addSeverityOverride(JObject props)
+        {
+            if (SeverityOverride is { } so)
+                props.Add(new JProperty("severityOverride", so.GetLiteral()));
         }
     }
 }

--- a/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
@@ -52,7 +52,9 @@ namespace Firely.Fhir.Validation
         TargetType = 2,
 
         /// <summary>
-        /// Validate the resolved target against the profiles applicable to its type.
+        /// Validate the resolved target against the profiles applicable to its type. Note that
+        /// selecting those profiles requires the target's type to match one of the target cases,
+        /// so a target matching no case is reported even when <see cref="TargetType"/> is not set.
         /// </summary>
         TargetProfile = 4,
 
@@ -169,6 +171,8 @@ namespace Firely.Fhir.Validation
             var cases = targetCases?.ToArray() ?? throw new ArgumentNullException(nameof(targetCases));
             if (cases.Length == 0)
                 throw new ArgumentException("At least one target case is required - a validator without cases could never accept a target.", nameof(targetCases));
+            if (cases.Select(c => c.Type).Distinct().Count() != cases.Length)
+                throw new ArgumentException("Target case types must be unique - dispatch always selects the first case for a type, so later duplicates would be unreachable.", nameof(targetCases));
 
             TargetCases = cases;
             AggregationRules = aggregationRules?.ToArray();
@@ -423,8 +427,10 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private TargetCase? findTargetCase(string typeName, PocoNode target, ValidationSettings vc)
         {
-            // The single "Resource" case matches every target - no dispatch needed.
-            if (_catchAllCase is not null) return _catchAllCase;
+            // The single "Resource" case matches every resource target - no dispatch needed. The
+            // POCO type test keeps this shortcut honest for the pathological case of an external
+            // resolver handing back a non-resource node: that falls through to the normal matching.
+            if (_catchAllCase is not null && target.Poco is Resource) return _catchAllCase;
 
             if (TargetCases!.FirstOrDefault(c => c.Type == typeName) is { } exact) return exact;
 

--- a/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Support;
@@ -21,7 +22,47 @@ using System.Runtime.Serialization;
 namespace Firely.Fhir.Validation
 {
     /// <summary>
-    /// Fetches an instance by reference and starts validation against a schema. The reference is 
+    /// The checks a <see cref="ReferencedInstanceValidator"/> performs on the target of a reference.
+    /// The checks on the reference value itself (parseability, aggregation and versioning rules)
+    /// always run.
+    /// </summary>
+    [Flags]
+#if NET8_0_OR_GREATER
+    [Experimental(diagnosticId: "ExperimentalApi")]
+#else
+    [Obsolete("This function is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.")]
+#endif
+    public enum ReferenceChecks
+    {
+        /// <summary>
+        /// Check nothing about the target: the reference is not resolved at all.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Check that the reference can be resolved.
+        /// </summary>
+        Exists = 1,
+
+        /// <summary>
+        /// Check that the reference resolves to a resource of one of the allowed target types
+        /// (see <see cref="ReferencedInstanceValidator.TargetCase.Type"/>).
+        /// </summary>
+        TargetType = 2,
+
+        /// <summary>
+        /// Validate the resolved target against the profiles applicable to its type.
+        /// </summary>
+        TargetProfile = 4,
+
+        /// <summary>
+        /// All checks, the validator's standard behavior.
+        /// </summary>
+        All = Exists | TargetType | TargetProfile
+    }
+
+    /// <summary>
+    /// Fetches an instance by reference and starts validation against a schema. The reference is
     /// to be found at runtime in the "reference" child of the input.
     /// </summary>
     [DataContract]
@@ -34,11 +75,51 @@ namespace Firely.Fhir.Validation
     public class ReferencedInstanceValidator : IValidatable
     {
         /// <summary>
+        /// The schema to validate the target of a reference against, for targets of a given type:
+        /// the explicit representation of the target types allowed by a reference.
+        /// </summary>
+        [DataContract]
+        public class TargetCase
+        {
+            /// <summary>
+            /// The type of target resource this case applies to. This may be an abstract base type
+            /// (e.g. <c>Resource</c> for references without target profiles), which matches all its
+            /// derived types.
+            /// </summary>
+            [DataMember]
+            public string Type { get; private set; }
+
+            /// <summary>
+            /// The schema to validate targets of this <see cref="Type"/> against, normally (a choice
+            /// of) the target profile(s) declared for that type.
+            /// </summary>
+            [DataMember]
+            public IAssertion Schema { get; private set; }
+
+            /// <summary>
+            /// Constructs a case for targets of the given type.
+            /// </summary>
+            public TargetCase(string type, IAssertion schema)
+            {
+                Type = type ?? throw new ArgumentNullException(nameof(type));
+                Schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            }
+        }
+
+        /// <summary>
         /// When the referenced resource was found, it will be validated against
-        /// this schema.
+        /// this schema. <c>null</c> when this validator dispatches on the target's type using
+        /// <see cref="TargetCases"/> instead.
         /// </summary>
         [DataMember]
-        public IAssertion Schema { get; private set; }
+        public IAssertion? Schema { get; private set; }
+
+        /// <summary>
+        /// The allowed target types and the schema to validate each type's targets against.
+        /// <c>null</c> when this validator validates every target against <see cref="Schema"/>.
+        /// </summary>
+        [DataMember]
+        public IReadOnlyList<TargetCase>? TargetCases { get; private set; }
 
         /// <summary>
         /// Additional rules about the context of the referenced resource.
@@ -53,10 +134,20 @@ namespace Firely.Fhir.Validation
         public ReferenceVersionRules? VersioningRules { get; private set; }
 
         /// <summary>
-        /// Create a <see cref="ReferencedInstanceValidator"/>.
+        /// The checks this validator performs on the target of the reference. Defaults to
+        /// <see cref="ReferenceChecks.All"/>, the validator's standard behavior.
         /// </summary>
+        [DataMember]
+        public ReferenceChecks Checks { get; private set; } = ReferenceChecks.All;
+
+        /// <summary>
+        /// Create a <see cref="ReferencedInstanceValidator"/> that validates every target against
+        /// a single schema, without checking the target's type.
+        /// </summary>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         public ReferencedInstanceValidator(IAssertion schema,
             IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null)
+#pragma warning restore RS0026
         {
             Schema = schema ?? throw new ArgumentNullException(nameof(schema));
             AggregationRules = aggregationRules?.ToArray();
@@ -64,9 +155,31 @@ namespace Firely.Fhir.Validation
         }
 
         /// <summary>
+        /// Create a <see cref="ReferencedInstanceValidator"/> that dispatches on the type of the
+        /// target: the target must be of one of the case types, and is validated against the schema
+        /// of the matching case.
+        /// </summary>
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+        public ReferencedInstanceValidator(IEnumerable<TargetCase> targetCases,
+            IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null,
+            ReferenceChecks checks = ReferenceChecks.All)
+#pragma warning restore RS0026
+        {
+            TargetCases = targetCases?.ToArray() ?? throw new ArgumentNullException(nameof(targetCases));
+            AggregationRules = aggregationRules?.ToArray();
+            VersioningRules = versioningRules;
+            Checks = checks;
+        }
+
+        /// <summary>
         /// Whether any <see cref="AggregationRules"/> have been specified on the constructor.
         /// </summary>
         public bool HasAggregation => AggregationRules?.Any() ?? false;
+
+        /// <summary>
+        /// Whether the current <see cref="Checks"/> require the target of the reference to be resolved.
+        /// </summary>
+        private bool needsTarget => Checks != ReferenceChecks.None;
 
         /// <inheritdoc cref="IValidatable.Validate(PocoNode, ValidationSettings, ValidationState)"/>
         ResultReport IValidatable.Validate(PocoNode input, ValidationSettings vc, ValidationState state)
@@ -104,6 +217,7 @@ namespace Firely.Fhir.Validation
                 // If the reference was resolved (either internally or externally), validate it
                 var referenceResolutionReport = resolution.ReferencedResource switch
                 {
+                    null when !needsTarget || !Checks.HasFlag(ReferenceChecks.Exists) => ResultReport.SUCCESS,
                     null when vc.ResolveExternalReference is null => ResultReport.SUCCESS,
                     null => new IssueAssertion(
                         Issue.UNAVAILABLE_REFERENCED_RESOURCE,
@@ -152,8 +266,9 @@ namespace Firely.Fhir.Validation
 
             if (resolution.ReferenceKind == AggregationMode.Referenced)
             {
-                // Bail out if we are asked to follow an *external reference* when this is disabled in the settings
-                if (vc.ResolveExternalReference is null)
+                // Bail out if we are asked to follow an *external reference* when this is disabled in
+                // the settings, or when none of the enabled checks need the target.
+                if (vc.ResolveExternalReference is null || !needsTarget)
                     return (evidence, resolution);
 
                 // If we are supposed to resolve the reference externally, then do so now.
@@ -231,7 +346,8 @@ namespace Firely.Fhir.Validation
         }
 
         /// <summary>
-        /// Validate the referenced resource against the <see cref="Schema"/>.
+        /// Validate the referenced resource against the <see cref="Schema"/> or the matching
+        /// <see cref="TargetCases"/> case.
         /// </summary>
         private ResultReport validateReferencedResource(string reference, ValidationSettings vc, ResolutionResult resolution, ValidationState state)
         {
@@ -243,29 +359,80 @@ namespace Firely.Fhir.Validation
             // references to external entities will operate within a new instance of a validator (and hence a new tracking context).
             // In both cases, the outcome is included in the result.
             if (resolution.ReferenceKind != AggregationMode.Referenced)
-                return Schema.ValidateOne(resolution.ReferencedResource.ToPocoNode(), vc, state);
+                return validateTarget(reference, resolution.ReferencedResource.ToPocoNode(), vc, state);
             else
             {
                 //TODO: We're using state to track the external URL, but this actually would be better
                 //implemented on the ScopedNode instead - add this (and combine with FullUrl?) there.
                 var newState = state.NewInstanceScope();
                 newState.Instance.ResourceUrl = reference;
-                return Schema.ValidateOne(resolution.ReferencedResource.ToPocoNode(), vc, newState);
+                return validateTarget(reference, resolution.ReferencedResource.ToPocoNode(), vc, newState);
             }
+        }
+
+        /// <summary>
+        /// Runs the target checks enabled in <see cref="Checks"/> on the resolved target: the type
+        /// dispatch over <see cref="TargetCases"/> and/or the validation against the (matching) schema.
+        /// </summary>
+        private ResultReport validateTarget(string reference, PocoNode target, ValidationSettings vc, ValidationState state)
+        {
+            // The legacy single-schema form does no type checking of its own.
+            if (TargetCases is null)
+            {
+                return Checks.HasFlag(ReferenceChecks.TargetProfile) && Schema is not null
+                    ? Schema.ValidateOne(target, vc, state)
+                    : ResultReport.SUCCESS;
+            }
+
+            if (!Checks.HasFlag(ReferenceChecks.TargetType) && !Checks.HasFlag(ReferenceChecks.TargetProfile))
+                return ResultReport.SUCCESS;
+
+            var typeName = target.Poco.TypeName;
+
+            if (findTargetCase(typeName, target, vc) is not { } matchingCase)
+            {
+                var allowed = string.Join(", ", TargetCases.Select(c => $"'{c.Type}'"));
+                return new IssueAssertion(Issue.CONTENT_ELEMENT_CHOICE_INVALID_INSTANCE_TYPE,
+                        $"Referenced resource '{reference}' is of type '{typeName}', which is not one of the allowed target types ({allowed}).")
+                    .AsResult(state, target, nameof(ReferencedInstanceValidator), this);
+            }
+
+            return Checks.HasFlag(ReferenceChecks.TargetProfile)
+                ? matchingCase.Schema.ValidateOne(target, vc, state)
+                : ResultReport.SUCCESS;
+        }
+
+        /// <summary>
+        /// Finds the case that applies to a target of the given type. Case types may be abstract
+        /// base types (e.g. <c>Resource</c>), which match all their derived types.
+        /// </summary>
+        private TargetCase? findTargetCase(string typeName, PocoNode target, ValidationSettings vc)
+        {
+            if (TargetCases!.FirstOrDefault(c => c.Type == typeName) is { } exact) return exact;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var inspector = vc.ModelInspector ?? ModelInspector.ForType(target.Poco.GetType());
+#pragma warning restore CS0618 // Type or member is obsolete
+            return TargetCases!.FirstOrDefault(c => inspector.IsInstanceTypeFor(c.Type, typeName));
         }
 
         /// <inheritdoc cref="IJsonSerializable.ToJson"/>
         public JToken ToJson()
         {
-            var result = new JObject
-            {
-                new JProperty("schema", Schema.ToJson().MakeNestedProp())
-            };
+            var result = new JObject();
+
+            if (Schema is not null)
+                result.Add(new JProperty("schema", Schema.ToJson().MakeNestedProp()));
+            if (TargetCases is not null)
+                result.Add(new JProperty("targets", new JObject(
+                    TargetCases.Select(c => new JProperty(c.Type, c.Schema.ToJson().MakeNestedProp())))));
 
             if (AggregationRules is not null)
                 result.Add(new JProperty("$aggregation", new JArray(AggregationRules.Select(ar => ar.ToString()))));
             if (VersioningRules is not null)
                 result.Add(new JProperty("$versioning", VersioningRules.ToString()));
+            if (Checks != ReferenceChecks.All)
+                result.Add(new JProperty("checks", Checks.ToString()));
 
             return new JProperty("validate", result);
         }

--- a/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
@@ -7,7 +7,6 @@
  */
 
 using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Introspection;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Support;
@@ -35,7 +34,9 @@ namespace Firely.Fhir.Validation
     public enum ReferenceChecks
     {
         /// <summary>
-        /// Check nothing about the target: the reference is not resolved at all.
+        /// Check nothing about the target. The reference is not resolved, unless aggregation
+        /// rules require determining the kind of reference; the checks on the reference value
+        /// itself still run.
         /// </summary>
         None = 0,
 
@@ -165,11 +166,21 @@ namespace Firely.Fhir.Validation
             ReferenceChecks checks = ReferenceChecks.All)
 #pragma warning restore RS0026
         {
-            TargetCases = targetCases?.ToArray() ?? throw new ArgumentNullException(nameof(targetCases));
+            var cases = targetCases?.ToArray() ?? throw new ArgumentNullException(nameof(targetCases));
+            if (cases.Length == 0)
+                throw new ArgumentException("At least one target case is required - a validator without cases could never accept a target.", nameof(targetCases));
+
+            TargetCases = cases;
             AggregationRules = aggregationRules?.ToArray();
             VersioningRules = versioningRules;
             Checks = checks;
+
+            // The common "any resource" reference (no target profiles) is compiled to a single
+            // "Resource" case - matching it needs no type dispatch at all, so precompute that.
+            _catchAllCase = cases is [{ Type: "Resource" } single] ? single : null;
         }
+
+        private readonly TargetCase? _catchAllCase;
 
         /// <summary>
         /// Whether any <see cref="AggregationRules"/> have been specified on the constructor.
@@ -217,7 +228,7 @@ namespace Firely.Fhir.Validation
                 // If the reference was resolved (either internally or externally), validate it
                 var referenceResolutionReport = resolution.ReferencedResource switch
                 {
-                    null when !needsTarget || !Checks.HasFlag(ReferenceChecks.Exists) => ResultReport.SUCCESS,
+                    null when !Checks.HasFlag(ReferenceChecks.Exists) => ResultReport.SUCCESS,
                     null when vc.ResolveExternalReference is null => ResultReport.SUCCESS,
                     null => new IssueAssertion(
                         Issue.UNAVAILABLE_REFERENCED_RESOURCE,
@@ -240,10 +251,15 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private (IReadOnlyCollection<ResultReport>, ResolutionResult) fetchReference(PocoNode input, string reference, ValidationSettings vc, ValidationState s)
         {
+            // The resolved resource is only needed for the target checks; the kind of reference
+            // (contained/bundled/referenced), which requires resolution too, only for the
+            // aggregation rules. Without either, resolution can be skipped altogether.
+            var needsResolution = needsTarget || HasAggregation;
+
             List<ResultReport> evidence =
             [
                 // First, try to resolve within this instance (in contained, Bundle.entry)
-                resolveLocally(input, reference, s, out var resolution)
+                resolveLocally(input, reference, needsResolution, s, out var resolution)
             ];
 
             // Now that we have tried to fetch the reference locally, we have also determined the kind of
@@ -294,8 +310,10 @@ namespace Firely.Fhir.Validation
 
         /// <summary>
         /// Try to fetch the resource within this instance (e.g. a contained or bundled resource).
+        /// The reference value itself is checked regardless, but the (potentially expensive) lookup
+        /// of the target is only done when <paramref name="resolve"/> is true.
         /// </summary>
-        private ResultReport resolveLocally(PocoNode instance, string reference, ValidationState s, out ResolutionResult resolution)
+        private ResultReport resolveLocally(PocoNode instance, string reference, bool resolve, ValidationState s, out ResolutionResult resolution)
         {
             resolution = new ResolutionResult(null, null, null);
             var identity = new ResourceIdentity(reference);
@@ -316,14 +334,14 @@ namespace Firely.Fhir.Validation
 
             try
             {
-                referencedResource = instance.Resolve(reference);
+                referencedResource = resolve ? instance.Resolve(reference) : null;
             }
             catch (Exception e)
             {
                 return new IssueAssertion(Issue.CONTENT_REFERENCE_NOT_RESOLVABLE,
                     $"Encountered an issue during reference resolution. Message: {e.Message}").AsResult(s, instance.ToPocoNode(), nameof(ReferencedInstanceValidator), this);
             }
-            
+
 
             resolution = identity.Form switch
             {
@@ -376,13 +394,10 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private ResultReport validateTarget(string reference, PocoNode target, ValidationSettings vc, ValidationState state)
         {
-            // The legacy single-schema form does no type checking of its own.
+            // The legacy single-schema form does no type checking of its own, and can only be
+            // constructed with Checks == All, so the target is always validated against the schema.
             if (TargetCases is null)
-            {
-                return Checks.HasFlag(ReferenceChecks.TargetProfile) && Schema is not null
-                    ? Schema.ValidateOne(target, vc, state)
-                    : ResultReport.SUCCESS;
-            }
+                return Schema!.ValidateOne(target, vc, state);
 
             if (!Checks.HasFlag(ReferenceChecks.TargetType) && !Checks.HasFlag(ReferenceChecks.TargetProfile))
                 return ResultReport.SUCCESS;
@@ -408,12 +423,21 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private TargetCase? findTargetCase(string typeName, PocoNode target, ValidationSettings vc)
         {
-            if (TargetCases!.FirstOrDefault(c => c.Type == typeName) is { } exact) return exact;
+            // The single "Resource" case matches every target - no dispatch needed. This runs
+            // per resolved reference, so avoid LINQ (closure allocations) in the loops below too.
+            if (_catchAllCase is not null) return _catchAllCase;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            var inspector = vc.ModelInspector ?? ModelInspector.ForType(target.Poco.GetType());
-#pragma warning restore CS0618 // Type or member is obsolete
-            return TargetCases!.FirstOrDefault(c => inspector.IsInstanceTypeFor(c.Type, typeName));
+            var cases = TargetCases!;
+
+            for (var i = 0; i < cases.Count; i++)
+                if (cases[i].Type == typeName) return cases[i];
+
+            var inspector = vc.GetModelInspector(target);
+
+            for (var i = 0; i < cases.Count; i++)
+                if (inspector.IsInstanceTypeFor(cases[i].Type, typeName)) return cases[i];
+
+            return null;
         }
 
         /// <inheritdoc cref="IJsonSerializable.ToJson"/>

--- a/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
@@ -423,21 +423,13 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private TargetCase? findTargetCase(string typeName, PocoNode target, ValidationSettings vc)
         {
-            // The single "Resource" case matches every target - no dispatch needed. This runs
-            // per resolved reference, so avoid LINQ (closure allocations) in the loops below too.
+            // The single "Resource" case matches every target - no dispatch needed.
             if (_catchAllCase is not null) return _catchAllCase;
 
-            var cases = TargetCases!;
-
-            for (var i = 0; i < cases.Count; i++)
-                if (cases[i].Type == typeName) return cases[i];
+            if (TargetCases!.FirstOrDefault(c => c.Type == typeName) is { } exact) return exact;
 
             var inspector = vc.GetModelInspector(target);
-
-            for (var i = 0; i < cases.Count; i++)
-                if (inspector.IsInstanceTypeFor(cases[i].Type, typeName)) return cases[i];
-
-            return null;
+            return TargetCases!.FirstOrDefault(c => inspector.IsInstanceTypeFor(c.Type, typeName));
         }
 
         /// <inheritdoc cref="IJsonSerializable.ToJson"/>

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -47,8 +47,16 @@ Firely.Fhir.Validation.BindingValidator.BindingStrength.Preferred = 2 -> Firely.
 Firely.Fhir.Validation.BindingValidator.BindingStrength.Required = 0 -> Firely.Fhir.Validation.BindingValidator.BindingStrength
 Firely.Fhir.Validation.BindingValidator.BindingValidator(Firely.Fhir.Validation.Canonical! valueSetUri, Firely.Fhir.Validation.BindingValidator.BindingStrength? strength, bool abstractAllowed = true) -> void
 Firely.Fhir.Validation.BindingValidator.Strength.get -> Firely.Fhir.Validation.BindingValidator.BindingStrength?
+Firely.Fhir.Validation.BindingValidator.BindingValidator(Firely.Fhir.Validation.Canonical! valueSetUri, Firely.Fhir.Validation.BindingValidator.BindingStrength? strength, bool abstractAllowed, Firely.Fhir.Validation.CodedContentChecks checks) -> void
+Firely.Fhir.Validation.BindingValidator.Checks.get -> Firely.Fhir.Validation.CodedContentChecks
 Firely.Fhir.Validation.BindingValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.BindingValidator.ValueSetUri.get -> Firely.Fhir.Validation.Canonical!
+Firely.Fhir.Validation.CodedContentChecks
+Firely.Fhir.Validation.CodedContentChecks.Concepts = 1 -> Firely.Fhir.Validation.CodedContentChecks
+Firely.Fhir.Validation.CodedContentChecks.Default = Firely.Fhir.Validation.CodedContentChecks.Concepts | Firely.Fhir.Validation.CodedContentChecks.Displays -> Firely.Fhir.Validation.CodedContentChecks
+Firely.Fhir.Validation.CodedContentChecks.Displays = 2 -> Firely.Fhir.Validation.CodedContentChecks
+Firely.Fhir.Validation.CodedContentChecks.None = 0 -> Firely.Fhir.Validation.CodedContentChecks
+Firely.Fhir.Validation.CodedContentChecks.Status = 4 -> Firely.Fhir.Validation.CodedContentChecks
 Firely.Fhir.Validation.CachedElementSchemaResolver
 Firely.Fhir.Validation.CachedElementSchemaResolver.CachedElementSchemaResolver(Firely.Fhir.Validation.IElementSchemaResolver! source) -> void
 Firely.Fhir.Validation.CachedElementSchemaResolver.CachedElementSchemaResolver(Firely.Fhir.Validation.IElementSchemaResolver! source, System.Collections.Concurrent.ConcurrentDictionary<Firely.Fhir.Validation.Canonical!, Firely.Fhir.Validation.ElementSchema?>! externalCache) -> void
@@ -246,11 +254,24 @@ Firely.Fhir.Validation.PatternValidator
 Firely.Fhir.Validation.PatternValidator.PatternValidator(Hl7.Fhir.Model.PocoNode! patternValue) -> void
 Firely.Fhir.Validation.PatternValidator.PatternValue.get -> Hl7.Fhir.Model.PocoNode!
 Firely.Fhir.Validation.PatternValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
+Firely.Fhir.Validation.ReferenceChecks
+Firely.Fhir.Validation.ReferenceChecks.All = Firely.Fhir.Validation.ReferenceChecks.Exists | Firely.Fhir.Validation.ReferenceChecks.TargetType | Firely.Fhir.Validation.ReferenceChecks.TargetProfile -> Firely.Fhir.Validation.ReferenceChecks
+Firely.Fhir.Validation.ReferenceChecks.Exists = 1 -> Firely.Fhir.Validation.ReferenceChecks
+Firely.Fhir.Validation.ReferenceChecks.None = 0 -> Firely.Fhir.Validation.ReferenceChecks
+Firely.Fhir.Validation.ReferenceChecks.TargetProfile = 4 -> Firely.Fhir.Validation.ReferenceChecks
+Firely.Fhir.Validation.ReferenceChecks.TargetType = 2 -> Firely.Fhir.Validation.ReferenceChecks
 Firely.Fhir.Validation.ReferencedInstanceValidator
 Firely.Fhir.Validation.ReferencedInstanceValidator.AggregationRules.get -> System.Collections.Generic.IReadOnlyCollection<Firely.Fhir.Validation.AggregationMode>?
+Firely.Fhir.Validation.ReferencedInstanceValidator.Checks.get -> Firely.Fhir.Validation.ReferenceChecks
 Firely.Fhir.Validation.ReferencedInstanceValidator.HasAggregation.get -> bool
 Firely.Fhir.Validation.ReferencedInstanceValidator.ReferencedInstanceValidator(Firely.Fhir.Validation.IAssertion! schema, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.AggregationMode>? aggregationRules = null, Firely.Fhir.Validation.ReferenceVersionRules? versioningRules = null) -> void
-Firely.Fhir.Validation.ReferencedInstanceValidator.Schema.get -> Firely.Fhir.Validation.IAssertion!
+Firely.Fhir.Validation.ReferencedInstanceValidator.ReferencedInstanceValidator(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase!>! targetCases, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.AggregationMode>? aggregationRules = null, Firely.Fhir.Validation.ReferenceVersionRules? versioningRules = null, Firely.Fhir.Validation.ReferenceChecks checks = Firely.Fhir.Validation.ReferenceChecks.All) -> void
+Firely.Fhir.Validation.ReferencedInstanceValidator.Schema.get -> Firely.Fhir.Validation.IAssertion?
+Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase
+Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase.Schema.get -> Firely.Fhir.Validation.IAssertion!
+Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase.TargetCase(string! type, Firely.Fhir.Validation.IAssertion! schema) -> void
+Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase.Type.get -> string!
+Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCases.get -> System.Collections.Generic.IReadOnlyList<Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase!>?
 Firely.Fhir.Validation.ReferencedInstanceValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.ReferencedInstanceValidator.VersioningRules.get -> Firely.Fhir.Validation.ReferenceVersionRules?
 Firely.Fhir.Validation.ReferenceVersionRules
@@ -498,3 +519,65 @@ virtual Firely.Fhir.Validation.ValidationState.<Clone>$() -> Firely.Fhir.Validat
 virtual Firely.Fhir.Validation.ValidationState.EqualityContract.get -> System.Type!
 virtual Firely.Fhir.Validation.ValidationState.Equals(Firely.Fhir.Validation.ValidationState? other) -> bool
 virtual Firely.Fhir.Validation.ValidationState.PrintMembers(System.Text.StringBuilder! builder) -> bool
+abstract Firely.Fhir.Validation.InvariantValidator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!
+Firely.Fhir.Validation.FhirEle1Validator.FhirEle1Validator(Firely.Fhir.Validation.FhirEle1Validator! original) -> void
+Firely.Fhir.Validation.FhirExt1Validator.FhirExt1Validator(Firely.Fhir.Validation.FhirExt1Validator! original) -> void
+Firely.Fhir.Validation.FhirPathValidator.FhirPathValidator(Firely.Fhir.Validation.FhirPathValidator! original) -> void
+Firely.Fhir.Validation.FhirTxt1Validator.FhirTxt1Validator(Firely.Fhir.Validation.FhirTxt1Validator! original) -> void
+Firely.Fhir.Validation.FhirTxt2Validator.FhirTxt2Validator(Firely.Fhir.Validation.FhirTxt2Validator! original) -> void
+Firely.Fhir.Validation.InvariantValidator.InvariantValidator(Firely.Fhir.Validation.InvariantValidator! original) -> void
+Firely.Fhir.Validation.InvariantValidator.SeverityOverride.get -> Hl7.Fhir.Model.OperationOutcome.IssueSeverity?
+Firely.Fhir.Validation.InvariantValidator.SeverityOverride.init -> void
+override Firely.Fhir.Validation.FhirEle1Validator.EqualityContract.get -> System.Type!
+override Firely.Fhir.Validation.FhirEle1Validator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.FhirEle1Validator.GetHashCode() -> int
+override Firely.Fhir.Validation.FhirEle1Validator.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Firely.Fhir.Validation.FhirEle1Validator.ToString() -> string!
+override Firely.Fhir.Validation.FhirExt1Validator.EqualityContract.get -> System.Type!
+override Firely.Fhir.Validation.FhirExt1Validator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.FhirExt1Validator.GetHashCode() -> int
+override Firely.Fhir.Validation.FhirExt1Validator.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Firely.Fhir.Validation.FhirExt1Validator.ToString() -> string!
+override Firely.Fhir.Validation.FhirPathValidator.EqualityContract.get -> System.Type!
+override Firely.Fhir.Validation.FhirPathValidator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.FhirPathValidator.GetHashCode() -> int
+override Firely.Fhir.Validation.FhirPathValidator.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Firely.Fhir.Validation.FhirPathValidator.ToString() -> string!
+override Firely.Fhir.Validation.FhirTxt1Validator.EqualityContract.get -> System.Type!
+override Firely.Fhir.Validation.FhirTxt1Validator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.FhirTxt1Validator.GetHashCode() -> int
+override Firely.Fhir.Validation.FhirTxt1Validator.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Firely.Fhir.Validation.FhirTxt1Validator.ToString() -> string!
+override Firely.Fhir.Validation.FhirTxt2Validator.EqualityContract.get -> System.Type!
+override Firely.Fhir.Validation.FhirTxt2Validator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.FhirTxt2Validator.GetHashCode() -> int
+override Firely.Fhir.Validation.FhirTxt2Validator.PrintMembers(System.Text.StringBuilder! builder) -> bool
+override Firely.Fhir.Validation.FhirTxt2Validator.ToString() -> string!
+override Firely.Fhir.Validation.InvariantValidator.Equals(object? obj) -> bool
+override Firely.Fhir.Validation.InvariantValidator.GetHashCode() -> int
+override Firely.Fhir.Validation.InvariantValidator.ToString() -> string!
+override sealed Firely.Fhir.Validation.FhirEle1Validator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+override sealed Firely.Fhir.Validation.FhirExt1Validator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+override sealed Firely.Fhir.Validation.FhirPathValidator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+override sealed Firely.Fhir.Validation.FhirTxt1Validator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+override sealed Firely.Fhir.Validation.FhirTxt2Validator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+static Firely.Fhir.Validation.FhirEle1Validator.operator !=(Firely.Fhir.Validation.FhirEle1Validator? left, Firely.Fhir.Validation.FhirEle1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirEle1Validator.operator ==(Firely.Fhir.Validation.FhirEle1Validator? left, Firely.Fhir.Validation.FhirEle1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirExt1Validator.operator !=(Firely.Fhir.Validation.FhirExt1Validator? left, Firely.Fhir.Validation.FhirExt1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirExt1Validator.operator ==(Firely.Fhir.Validation.FhirExt1Validator? left, Firely.Fhir.Validation.FhirExt1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirPathValidator.operator !=(Firely.Fhir.Validation.FhirPathValidator? left, Firely.Fhir.Validation.FhirPathValidator? right) -> bool
+static Firely.Fhir.Validation.FhirPathValidator.operator ==(Firely.Fhir.Validation.FhirPathValidator? left, Firely.Fhir.Validation.FhirPathValidator? right) -> bool
+static Firely.Fhir.Validation.FhirTxt1Validator.operator !=(Firely.Fhir.Validation.FhirTxt1Validator? left, Firely.Fhir.Validation.FhirTxt1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirTxt1Validator.operator ==(Firely.Fhir.Validation.FhirTxt1Validator? left, Firely.Fhir.Validation.FhirTxt1Validator? right) -> bool
+static Firely.Fhir.Validation.FhirTxt2Validator.operator !=(Firely.Fhir.Validation.FhirTxt2Validator? left, Firely.Fhir.Validation.FhirTxt2Validator? right) -> bool
+static Firely.Fhir.Validation.FhirTxt2Validator.operator ==(Firely.Fhir.Validation.FhirTxt2Validator? left, Firely.Fhir.Validation.FhirTxt2Validator? right) -> bool
+static Firely.Fhir.Validation.InvariantValidator.operator !=(Firely.Fhir.Validation.InvariantValidator? left, Firely.Fhir.Validation.InvariantValidator? right) -> bool
+static Firely.Fhir.Validation.InvariantValidator.operator ==(Firely.Fhir.Validation.InvariantValidator? left, Firely.Fhir.Validation.InvariantValidator? right) -> bool
+virtual Firely.Fhir.Validation.FhirEle1Validator.Equals(Firely.Fhir.Validation.FhirEle1Validator? other) -> bool
+virtual Firely.Fhir.Validation.FhirExt1Validator.Equals(Firely.Fhir.Validation.FhirExt1Validator? other) -> bool
+virtual Firely.Fhir.Validation.FhirPathValidator.Equals(Firely.Fhir.Validation.FhirPathValidator? other) -> bool
+virtual Firely.Fhir.Validation.FhirTxt1Validator.Equals(Firely.Fhir.Validation.FhirTxt1Validator? other) -> bool
+virtual Firely.Fhir.Validation.FhirTxt2Validator.Equals(Firely.Fhir.Validation.FhirTxt2Validator? other) -> bool
+virtual Firely.Fhir.Validation.InvariantValidator.EqualityContract.get -> System.Type!
+virtual Firely.Fhir.Validation.InvariantValidator.Equals(Firely.Fhir.Validation.InvariantValidator? other) -> bool
+virtual Firely.Fhir.Validation.InvariantValidator.PrintMembers(System.Text.StringBuilder! builder) -> bool

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -47,7 +47,7 @@ Firely.Fhir.Validation.BindingValidator.BindingStrength.Preferred = 2 -> Firely.
 Firely.Fhir.Validation.BindingValidator.BindingStrength.Required = 0 -> Firely.Fhir.Validation.BindingValidator.BindingStrength
 Firely.Fhir.Validation.BindingValidator.BindingValidator(Firely.Fhir.Validation.Canonical! valueSetUri, Firely.Fhir.Validation.BindingValidator.BindingStrength? strength, bool abstractAllowed = true) -> void
 Firely.Fhir.Validation.BindingValidator.Strength.get -> Firely.Fhir.Validation.BindingValidator.BindingStrength?
-Firely.Fhir.Validation.BindingValidator.BindingValidator(Firely.Fhir.Validation.Canonical! valueSetUri, Firely.Fhir.Validation.BindingValidator.BindingStrength? strength, bool abstractAllowed, Firely.Fhir.Validation.CodedContentChecks checks) -> void
+Firely.Fhir.Validation.BindingValidator.BindingValidator(Firely.Fhir.Validation.Canonical! valueSetUri, Firely.Fhir.Validation.BindingValidator.BindingStrength? strength, bool abstractAllowed, Firely.Fhir.Validation.CodedContentChecks checks = Firely.Fhir.Validation.CodedContentChecks.Default) -> void
 Firely.Fhir.Validation.BindingValidator.Checks.get -> Firely.Fhir.Validation.CodedContentChecks
 Firely.Fhir.Validation.BindingValidator.ToJson() -> Newtonsoft.Json.Linq.JToken!
 Firely.Fhir.Validation.BindingValidator.ValueSetUri.get -> Firely.Fhir.Validation.Canonical!

--- a/src/Firely.Fhir.Validation/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+override Firely.Fhir.Validation.FhirEle1Validator.<Clone>$() -> Firely.Fhir.Validation.FhirEle1Validator!
+override Firely.Fhir.Validation.FhirExt1Validator.<Clone>$() -> Firely.Fhir.Validation.FhirExt1Validator!
+override Firely.Fhir.Validation.FhirPathValidator.<Clone>$() -> Firely.Fhir.Validation.FhirPathValidator!
+override Firely.Fhir.Validation.FhirTxt1Validator.<Clone>$() -> Firely.Fhir.Validation.FhirTxt1Validator!
+override Firely.Fhir.Validation.FhirTxt2Validator.<Clone>$() -> Firely.Fhir.Validation.FhirTxt2Validator!

--- a/src/Firely.Fhir.Validation/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+override Firely.Fhir.Validation.FhirEle1Validator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!
+override Firely.Fhir.Validation.FhirExt1Validator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!
+override Firely.Fhir.Validation.FhirPathValidator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!
+override Firely.Fhir.Validation.FhirTxt1Validator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!
+override Firely.Fhir.Validation.FhirTxt2Validator.<Clone>$() -> Firely.Fhir.Validation.InvariantValidator!

--- a/src/Firely.Fhir.Validation/Schema/ValidationSettings.cs
+++ b/src/Firely.Fhir.Validation/Schema/ValidationSettings.cs
@@ -70,8 +70,8 @@ namespace Firely.Fhir.Validation
             FollowExtensionUrl = original.FollowExtensionUrl;
             ConformanceResourceResolver = original.ConformanceResourceResolver;
             TransformIssues = original.TransformIssues;
-            IncludeFilters = new List<Predicate<IAssertion>>(original.IncludeFilters);
-            ExcludeFilters = new List<Predicate<IAssertion>>(original.ExcludeFilters);
+            IncludeFilters = [.. original.IncludeFilters];
+            ExcludeFilters = [.. original.ExcludeFilters];
             TraceEnabled = original.TraceEnabled;
         }
 
@@ -180,13 +180,13 @@ namespace Firely.Fhir.Validation
         /// A function to include the assertion in the validation or not. If the function is left empty (null) then all the 
         /// assertions are processed in the validation.
         /// </summary>
-        public ICollection<Predicate<IAssertion>> IncludeFilters = new List<Predicate<IAssertion>>();
+        public ICollection<Predicate<IAssertion>> IncludeFilters = [];
 
         /// <summary>
         /// A function to exclude the assertion in the validation or not. If the function is left empty (null) then all the 
         /// assertions are processed in the validation.
         /// </summary>
-        public ICollection<Predicate<IAssertion>> ExcludeFilters = new List<Predicate<IAssertion>> { DEFAULTEXCLUDEFILTER };
+        public ICollection<Predicate<IAssertion>> ExcludeFilters = [DEFAULTEXCLUDEFILTER];
 
         /// <summary>
         /// The default for <see cref="ExcludeFilters"/>, which will exclude FhirPath invariant dom-6 from triggering.

--- a/src/Firely.Fhir.Validation/Support/ModelInspectorExtensions.cs
+++ b/src/Firely.Fhir.Validation/Support/ModelInspectorExtensions.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
+
+namespace Firely.Fhir.Validation
+{
+    /// <summary>
+    /// The validator-wide strategy for obtaining a <see cref="ModelInspector"/> during validation.
+    /// </summary>
+    internal static class ModelInspectorExtensions
+    {
+        /// <summary>
+        /// Returns the <see cref="ModelInspector"/> to use for inspecting FHIR model metadata:
+        /// the one configured on the settings when present, otherwise one derived from the type
+        /// of the given context node's POCO.
+        /// </summary>
+        /// <remarks>We introduced <see cref="ValidationSettings.ModelInspector"/> to be able to
+        /// express the model to validate against properly, but for legacy call sites we fall back
+        /// to the obsoleted <c>ModelInspector.ForType()</c> to retrieve the inspector for the POCO
+        /// itself. That might end up being <c>ModelInspector.Base</c> for custom types, which can
+        /// misjudge e.g. choice-type membership - see the remarks (and the unit test referenced
+        /// there) in <c>ExtensionContextValidator.validateElementContext</c>.</remarks>
+        public static ModelInspector GetModelInspector(this ValidationSettings vc, PocoNode context)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            return vc.ModelInspector ?? ModelInspector.ForType(context.Poco.GetType());
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+    }
+}

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Composition.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Composition.json
@@ -163,8 +163,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -187,8 +189,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -217,80 +221,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
               }
             }
           }
@@ -376,70 +324,21 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -465,8 +364,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -543,8 +444,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                        "targets": {
+                          "Composition": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                          }
                         }
                       }
                     }
@@ -630,8 +533,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -733,80 +638,24 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forDevice",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Device"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                        }
-                      },
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Device": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+                  },
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -830,8 +679,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -882,8 +733,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Extension.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Extension.json
@@ -417,8 +417,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Patient.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Patient.json
@@ -352,8 +352,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -438,50 +440,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -505,8 +472,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -558,40 +527,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/PatternSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/PatternSlice.json
@@ -189,8 +189,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -298,8 +300,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -537,8 +541,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -609,50 +615,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -669,8 +640,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -715,40 +688,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledFlag.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledFlag.json
@@ -154,55 +154,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
+            "targets": {
+              "Organization": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
                     },
-                    "assertion": {
-                      "anyOf": {
-                        "members": [
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
-                          },
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
-                          }
-                        ],
-                        "issue": {
-                          "issueNumber": 1011,
-                          "severity": "Error",
-                          "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
-                          "type": "Invalid"
-                        }
-                      }
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
                     }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
-                    }
-                  }
-                ],
-                "default": {
+                  ],
                   "issue": {
                     "issueNumber": 1011,
                     "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2, http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure). None of these are profiles on type %INSTANCETYPE% of the resource.",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
                     "type": "Invalid"
                   }
                 }
+              },
+              "Procedure": {
+                "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
               }
             }
           }
@@ -225,8 +197,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -242,70 +216,21 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledObservation.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledObservation.json
@@ -134,80 +134,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forDeviceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
-                    }
-                  },
-                  {
-                    "name": "forImmunizationRecommendation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImmunizationRecommendation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-                    }
-                  },
-                  {
-                    "name": "forMedicationRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-                    }
-                  },
-                  {
-                    "name": "forNutritionOrder",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "NutritionOrder"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
-                    }
-                  },
-                  {
-                    "name": "forServiceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ServiceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/DeviceRequest, http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation, http://hl7.org/fhir/StructureDefinition/MedicationRequest, http://hl7.org/fhir/StructureDefinition/NutritionOrder, http://hl7.org/fhir/StructureDefinition/ServiceRequest). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "DeviceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
+              },
+              "ImmunizationRecommendation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+              },
+              "MedicationRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+              },
+              "NutritionOrder": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
+              },
+              "ServiceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
               }
             }
           }
@@ -224,80 +168,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forMedicationAdministration",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationAdministration"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
-                    }
-                  },
-                  {
-                    "name": "forMedicationDispense",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationDispense"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
-                    }
-                  },
-                  {
-                    "name": "forMedicationStatement",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationStatement"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
-                    }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
-                    }
-                  },
-                  {
-                    "name": "forImmunization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Immunization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/MedicationAdministration, http://hl7.org/fhir/StructureDefinition/MedicationDispense, http://hl7.org/fhir/StructureDefinition/MedicationStatement, http://hl7.org/fhir/StructureDefinition/Procedure, http://hl7.org/fhir/StructureDefinition/Immunization, http://hl7.org/fhir/StructureDefinition/ImagingStudy). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "MedicationAdministration": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
+              },
+              "MedicationDispense": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
+              },
+              "MedicationStatement": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
+              },
+              "Procedure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
+              },
+              "Immunization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
               }
             }
           }
@@ -347,21 +235,23 @@
         },
         {
           "validate": {
-            "schema": {
-              "anyOf": {
-                "members": [
-                  {
-                    "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
-                  },
-                  {
-                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+            "targets": {
+              "Patient": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
+                    },
+                    {
+                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                    }
+                  ],
+                  "issue": {
+                    "issueNumber": 1011,
+                    "severity": "Error",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
+                    "type": "Invalid"
                   }
-                ],
-                "issue": {
-                  "issueNumber": 1011,
-                  "severity": "Error",
-                  "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
-                  "type": "Invalid"
                 }
               }
             }
@@ -423,8 +313,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -440,8 +332,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -522,80 +416,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -791,8 +629,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+            "targets": {
+              "Specimen": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+              }
             }
           }
         }
@@ -808,40 +648,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forDeviceMetric",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceMetric"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/DeviceMetric). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "DeviceMetric": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
               }
             }
           }
@@ -938,50 +750,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/MolecularSequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
               }
             }
           }
@@ -998,80 +775,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  },
-                  {
-                    "name": "forMedia",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Media"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Media"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/ImagingStudy, http://hl7.org/fhir/StructureDefinition/Media, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/MolecularSequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              },
+              "Media": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Media"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledQuestionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/ProfiledQuestionnaire.json
@@ -587,8 +587,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -753,8 +755,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -944,8 +948,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Questionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/Questionnaire.json
@@ -676,8 +676,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -842,8 +844,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -1033,8 +1037,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/SecondaryTypeRefSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4/SchemaSnaps/SecondaryTypeRefSlice.json
@@ -131,8 +131,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -148,8 +150,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -165,8 +169,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+            "targets": {
+              "Communication": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+              }
             }
           }
         }
@@ -237,40 +243,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -298,8 +276,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -315,8 +295,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -344,110 +326,33 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Group, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
               }
             }
           }
@@ -464,90 +369,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
               }
             }
           }
@@ -575,60 +417,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCondition",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Condition"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forDiagnosticReport",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DiagnosticReport"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-                    }
-                  },
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Condition, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/DiagnosticReport, http://hl7.org/fhir/StructureDefinition/DocumentReference). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Condition": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "DiagnosticReport": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+              },
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
               }
             }
           }
@@ -694,40 +494,12 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "slice": {
-                            "ordered": false,
-                            "defaultAtEnd": false,
-                            "case": [
-                              {
-                                "name": "forDocumentReference",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "DocumentReference"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                                }
-                              },
-                              {
-                                "name": "forTask",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "Task"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/Task"
-                                }
-                              }
-                            ],
-                            "default": {
-                              "issue": {
-                                "issueNumber": 1011,
-                                "severity": "Error",
-                                "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/Task). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                                "type": "Invalid"
-                              }
-                            }
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          },
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
                           }
                         }
                       }
@@ -863,8 +635,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          }
                         }
                       }
                     }
@@ -937,8 +711,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                        "targets": {
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Composition.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Composition.json
@@ -170,8 +170,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -194,8 +196,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -224,80 +228,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
               }
             }
           }
@@ -383,70 +331,21 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -472,8 +371,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -550,8 +451,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                        "targets": {
+                          "Composition": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                          }
                         }
                       }
                     }
@@ -637,8 +540,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -740,80 +645,24 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forDevice",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Device"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                        }
-                      },
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Device": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+                  },
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -837,8 +686,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -889,8 +740,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Extension.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Extension.json
@@ -297,8 +297,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }
@@ -448,8 +450,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Patient.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Patient.json
@@ -359,8 +359,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -445,50 +447,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -512,8 +479,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -565,40 +534,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/PatternSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/PatternSlice.json
@@ -196,8 +196,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -305,8 +307,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -544,8 +548,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -616,50 +622,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -676,8 +647,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -722,40 +695,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledFlag.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledFlag.json
@@ -161,55 +161,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
+            "targets": {
+              "Organization": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
                     },
-                    "assertion": {
-                      "anyOf": {
-                        "members": [
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
-                          },
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
-                          }
-                        ],
-                        "issue": {
-                          "issueNumber": 1011,
-                          "severity": "Error",
-                          "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
-                          "type": "Invalid"
-                        }
-                      }
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
                     }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
-                    }
-                  }
-                ],
-                "default": {
+                  ],
                   "issue": {
                     "issueNumber": 1011,
                     "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2, http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure). None of these are profiles on type %INSTANCETYPE% of the resource.",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
                     "type": "Invalid"
                   }
                 }
+              },
+              "Procedure": {
+                "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
               }
             }
           }
@@ -232,8 +204,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -249,70 +223,21 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledObservation.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledObservation.json
@@ -141,80 +141,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forDeviceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
-                    }
-                  },
-                  {
-                    "name": "forImmunizationRecommendation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImmunizationRecommendation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-                    }
-                  },
-                  {
-                    "name": "forMedicationRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-                    }
-                  },
-                  {
-                    "name": "forNutritionOrder",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "NutritionOrder"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
-                    }
-                  },
-                  {
-                    "name": "forServiceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ServiceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/DeviceRequest, http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation, http://hl7.org/fhir/StructureDefinition/MedicationRequest, http://hl7.org/fhir/StructureDefinition/NutritionOrder, http://hl7.org/fhir/StructureDefinition/ServiceRequest). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "DeviceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
+              },
+              "ImmunizationRecommendation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+              },
+              "MedicationRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+              },
+              "NutritionOrder": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
+              },
+              "ServiceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
               }
             }
           }
@@ -231,80 +175,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forMedicationAdministration",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationAdministration"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
-                    }
-                  },
-                  {
-                    "name": "forMedicationDispense",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationDispense"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
-                    }
-                  },
-                  {
-                    "name": "forMedicationStatement",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationStatement"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
-                    }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
-                    }
-                  },
-                  {
-                    "name": "forImmunization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Immunization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/MedicationAdministration, http://hl7.org/fhir/StructureDefinition/MedicationDispense, http://hl7.org/fhir/StructureDefinition/MedicationStatement, http://hl7.org/fhir/StructureDefinition/Procedure, http://hl7.org/fhir/StructureDefinition/Immunization, http://hl7.org/fhir/StructureDefinition/ImagingStudy). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "MedicationAdministration": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
+              },
+              "MedicationDispense": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
+              },
+              "MedicationStatement": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
+              },
+              "Procedure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
+              },
+              "Immunization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
               }
             }
           }
@@ -354,21 +242,23 @@
         },
         {
           "validate": {
-            "schema": {
-              "anyOf": {
-                "members": [
-                  {
-                    "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
-                  },
-                  {
-                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+            "targets": {
+              "Patient": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
+                    },
+                    {
+                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                    }
+                  ],
+                  "issue": {
+                    "issueNumber": 1011,
+                    "severity": "Error",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
+                    "type": "Invalid"
                   }
-                ],
-                "issue": {
-                  "issueNumber": 1011,
-                  "severity": "Error",
-                  "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
-                  "type": "Invalid"
                 }
               }
             }
@@ -430,8 +320,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -447,8 +339,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -529,80 +423,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -798,8 +636,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+            "targets": {
+              "Specimen": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+              }
             }
           }
         }
@@ -815,40 +655,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forDeviceMetric",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceMetric"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/DeviceMetric). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "DeviceMetric": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
               }
             }
           }
@@ -945,50 +757,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/MolecularSequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
               }
             }
           }
@@ -1005,80 +782,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  },
-                  {
-                    "name": "forMedia",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Media"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Media"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/ImagingStudy, http://hl7.org/fhir/StructureDefinition/Media, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/MolecularSequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              },
+              "Media": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Media"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledQuestionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/ProfiledQuestionnaire.json
@@ -608,8 +608,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -774,8 +776,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -965,8 +969,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Questionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/Questionnaire.json
@@ -711,8 +711,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -877,8 +879,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -1068,8 +1072,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/SecondaryTypeRefSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R4B/SchemaSnaps/SecondaryTypeRefSlice.json
@@ -138,8 +138,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -155,8 +157,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -172,8 +176,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+            "targets": {
+              "Communication": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+              }
             }
           }
         }
@@ -244,40 +250,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -305,8 +283,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -322,8 +302,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -351,110 +333,33 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Group, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
               }
             }
           }
@@ -471,90 +376,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
               }
             }
           }
@@ -582,60 +424,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCondition",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Condition"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forDiagnosticReport",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DiagnosticReport"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-                    }
-                  },
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Condition, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/DiagnosticReport, http://hl7.org/fhir/StructureDefinition/DocumentReference). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Condition": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "DiagnosticReport": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+              },
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
               }
             }
           }
@@ -701,40 +501,12 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "slice": {
-                            "ordered": false,
-                            "defaultAtEnd": false,
-                            "case": [
-                              {
-                                "name": "forDocumentReference",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "DocumentReference"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                                }
-                              },
-                              {
-                                "name": "forTask",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "Task"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/Task"
-                                }
-                              }
-                            ],
-                            "default": {
-                              "issue": {
-                                "issueNumber": 1011,
-                                "severity": "Error",
-                                "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/Task). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                                "type": "Invalid"
-                              }
-                            }
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          },
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
                           }
                         }
                       }
@@ -870,8 +642,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          }
                         }
                       }
                     }
@@ -944,8 +718,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                        "targets": {
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Composition.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Composition.json
@@ -189,8 +189,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -220,8 +222,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -263,80 +267,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
               }
             }
           }
@@ -430,70 +378,21 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -526,8 +425,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -592,8 +493,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -702,80 +605,24 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forDevice",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Device"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                        }
-                      },
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Device": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+                  },
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -806,8 +653,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -854,8 +703,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Extension.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Extension.json
@@ -307,8 +307,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }
@@ -458,8 +460,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ImagingSelection.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ImagingSelection.json
@@ -152,120 +152,36 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forLocation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Location"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Location"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forMedication",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Medication"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Medication"
-                    }
-                  },
-                  {
-                    "name": "forSubstance",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Substance"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Substance"
-                    }
-                  },
-                  {
-                    "name": "forSpecimen",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Specimen"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Location, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Procedure, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/Medication, http://hl7.org/fhir/StructureDefinition/Substance, http://hl7.org/fhir/StructureDefinition/Specimen). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Location": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Procedure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "Medication": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Medication"
+              },
+              "Substance": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Substance"
+              },
+              "Specimen": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
               }
             }
           }
@@ -338,100 +254,30 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forDevice",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Device"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      },
-                      {
-                        "name": "forCareTeam",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "CareTeam"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                        }
-                      },
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forHealthcareService",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "HealthcareService"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Device": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  },
+                  "CareTeam": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                  },
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "HealthcareService": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
                   }
                 }
               }
@@ -464,70 +310,21 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forServiceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ServiceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                    }
-                  },
-                  {
-                    "name": "forAppointment",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Appointment"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Appointment"
-                    }
-                  },
-                  {
-                    "name": "forAppointmentResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "AppointmentResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/AppointmentResponse"
-                    }
-                  },
-                  {
-                    "name": "forTask",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Task"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Task"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/ServiceRequest, http://hl7.org/fhir/StructureDefinition/Appointment, http://hl7.org/fhir/StructureDefinition/AppointmentResponse, http://hl7.org/fhir/StructureDefinition/Task). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "ServiceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+              },
+              "Appointment": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Appointment"
+              },
+              "AppointmentResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/AppointmentResponse"
+              },
+              "Task": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Task"
               }
             }
           }
@@ -586,40 +383,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  },
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/ImagingStudy, http://hl7.org/fhir/StructureDefinition/DocumentReference). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              },
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
               }
             }
           }
@@ -650,8 +419,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
+            "targets": {
+              "Endpoint": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
+              }
             }
           }
         }
@@ -690,8 +461,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/BodyStructure"
+            "targets": {
+              "BodyStructure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/BodyStructure"
+              }
             }
           }
         }
@@ -721,8 +494,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/ImagingSelection"
+            "targets": {
+              "ImagingSelection": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingSelection"
+              }
             }
           }
         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Patient.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Patient.json
@@ -366,8 +366,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -459,50 +461,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -533,8 +500,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -593,40 +562,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/PatternSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/PatternSlice.json
@@ -189,8 +189,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -298,8 +300,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -537,8 +541,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -609,50 +615,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }
@@ -669,8 +640,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -715,40 +688,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledEncounter.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledEncounter.json
@@ -168,8 +168,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
+            "targets": {
+              "Organization": {
+                "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
+              }
             }
           }
         }
@@ -185,40 +187,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -246,8 +220,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
+            "targets": {
+              "EpisodeOfCare": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
+              }
             }
           }
         }
@@ -263,60 +239,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forDeviceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
-                    }
-                  },
-                  {
-                    "name": "forMedicationRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-                    }
-                  },
-                  {
-                    "name": "forServiceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ServiceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/DeviceRequest, http://hl7.org/fhir/StructureDefinition/MedicationRequest, http://hl7.org/fhir/StructureDefinition/ServiceRequest). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "DeviceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
+              },
+              "MedicationRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+              },
+              "ServiceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
               }
             }
           }
@@ -333,8 +267,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+            "targets": {
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              }
             }
           }
         }
@@ -350,8 +286,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -367,8 +305,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -440,90 +380,27 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forGroup",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Group"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      },
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forPractitionerRole",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "PractitionerRole"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                        }
-                      },
-                      {
-                        "name": "forDevice",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Device"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                        }
-                      },
-                      {
-                        "name": "forHealthcareService",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "HealthcareService"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/HealthcareService). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "Group": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Group"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                  },
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "PractitionerRole": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                  },
+                  "Device": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+                  },
+                  "HealthcareService": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
                   }
                 }
               }
@@ -542,8 +419,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Appointment"
+            "targets": {
+              "Appointment": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Appointment"
+              }
             }
           }
         }
@@ -630,70 +509,21 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forCondition",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Condition"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
-                        }
-                      },
-                      {
-                        "name": "forDiagnosticReport",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "DiagnosticReport"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-                        }
-                      },
-                      {
-                        "name": "forObservation",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Observation"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                        }
-                      },
-                      {
-                        "name": "forImmunizationRecommendation",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "ImmunizationRecommendation"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-                        }
-                      },
-                      {
-                        "name": "forProcedure",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Procedure"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Condition, http://hl7.org/fhir/StructureDefinition/DiagnosticReport, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation, http://hl7.org/fhir/StructureDefinition/Procedure). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Condition": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+                  },
+                  "DiagnosticReport": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+                  },
+                  "Observation": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+                  },
+                  "ImmunizationRecommendation": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                  },
+                  "Procedure": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
                   }
                 }
               }
@@ -742,8 +572,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+                "targets": {
+                  "Condition": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+                  }
                 }
               }
             }
@@ -772,8 +604,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Account"
+            "targets": {
+              "Account": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Account"
+              }
             }
           }
         }
@@ -853,40 +687,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forLocation",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Location"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Location"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Location, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Location": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -925,40 +731,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forLocation",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Location"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Location"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Location, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Location": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -1016,8 +794,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+                "targets": {
+                  "Location": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+                  }
                 }
               }
             }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledFlag.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledFlag.json
@@ -154,55 +154,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
+            "targets": {
+              "Organization": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
                     },
-                    "assertion": {
-                      "anyOf": {
-                        "members": [
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
-                          },
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
-                          }
-                        ],
-                        "issue": {
-                          "issueNumber": 1011,
-                          "severity": "Error",
-                          "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
-                          "type": "Invalid"
-                        }
-                      }
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
                     }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
-                    }
-                  }
-                ],
-                "default": {
+                  ],
                   "issue": {
                     "issueNumber": 1011,
                     "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2, http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure). None of these are profiles on type %INSTANCETYPE% of the resource.",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
                     "type": "Invalid"
                   }
                 }
+              },
+              "Procedure": {
+                "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
               }
             }
           }
@@ -225,8 +197,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -242,80 +216,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledObservation.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledObservation.json
@@ -162,8 +162,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ObservationDefinition"
+                    "targets": {
+                      "ObservationDefinition": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/ObservationDefinition"
+                      }
                     }
                   }
                 }
@@ -191,80 +193,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forDeviceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
-                    }
-                  },
-                  {
-                    "name": "forImmunizationRecommendation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImmunizationRecommendation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-                    }
-                  },
-                  {
-                    "name": "forMedicationRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-                    }
-                  },
-                  {
-                    "name": "forNutritionOrder",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "NutritionOrder"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
-                    }
-                  },
-                  {
-                    "name": "forServiceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ServiceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/DeviceRequest, http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation, http://hl7.org/fhir/StructureDefinition/MedicationRequest, http://hl7.org/fhir/StructureDefinition/NutritionOrder, http://hl7.org/fhir/StructureDefinition/ServiceRequest). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "DeviceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
+              },
+              "ImmunizationRecommendation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+              },
+              "MedicationRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+              },
+              "NutritionOrder": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
+              },
+              "ServiceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
               }
             }
           }
@@ -310,8 +256,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+                "targets": {
+                  "Observation": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+                  }
                 }
               }
             }
@@ -346,90 +294,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forMedicationAdministration",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationAdministration"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
-                    }
-                  },
-                  {
-                    "name": "forMedicationDispense",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationDispense"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
-                    }
-                  },
-                  {
-                    "name": "forMedicationStatement",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationStatement"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
-                    }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
-                    }
-                  },
-                  {
-                    "name": "forImmunization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Immunization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  },
-                  {
-                    "name": "forGenomicStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "GenomicStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/GenomicStudy"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/MedicationAdministration, http://hl7.org/fhir/StructureDefinition/MedicationDispense, http://hl7.org/fhir/StructureDefinition/MedicationStatement, http://hl7.org/fhir/StructureDefinition/Procedure, http://hl7.org/fhir/StructureDefinition/Immunization, http://hl7.org/fhir/StructureDefinition/ImagingStudy, http://hl7.org/fhir/StructureDefinition/GenomicStudy). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "MedicationAdministration": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
+              },
+              "MedicationDispense": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationDispense"
+              },
+              "MedicationStatement": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationStatement"
+              },
+              "Procedure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Procedure"
+              },
+              "Immunization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Immunization"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              },
+              "GenomicStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/GenomicStudy"
               }
             }
           }
@@ -479,21 +364,23 @@
         },
         {
           "validate": {
-            "schema": {
-              "anyOf": {
-                "members": [
-                  {
-                    "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
-                  },
-                  {
-                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+            "targets": {
+              "Patient": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
+                    },
+                    {
+                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                    }
+                  ],
+                  "issue": {
+                    "issueNumber": 1011,
+                    "severity": "Error",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
+                    "type": "Invalid"
                   }
-                ],
-                "issue": {
-                  "issueNumber": 1011,
-                  "severity": "Error",
-                  "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
-                  "type": "Invalid"
                 }
               }
             }
@@ -555,8 +442,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -572,8 +461,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -654,80 +545,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -875,8 +710,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                    "targets": {
+                      "MolecularSequence": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                      }
                     }
                   }
                 }
@@ -943,8 +780,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/BodyStructure"
+            "targets": {
+              "BodyStructure": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/BodyStructure"
+              }
             }
           }
         }
@@ -978,40 +817,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forSpecimen",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Specimen"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Specimen, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Specimen": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -1028,40 +839,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forDeviceMetric",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceMetric"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/DeviceMetric). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "DeviceMetric": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
               }
             }
           }
@@ -1169,50 +952,15 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/MolecularSequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
               }
             }
           }
@@ -1229,90 +977,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDocumentReference",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DocumentReference"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                    }
-                  },
-                  {
-                    "name": "forImagingStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-                    }
-                  },
-                  {
-                    "name": "forImagingSelection",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImagingSelection"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImagingSelection"
-                    }
-                  },
-                  {
-                    "name": "forQuestionnaireResponse",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "QuestionnaireResponse"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  },
-                  {
-                    "name": "forMolecularSequence",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MolecularSequence"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-                    }
-                  },
-                  {
-                    "name": "forGenomicStudy",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "GenomicStudy"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/GenomicStudy"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/ImagingStudy, http://hl7.org/fhir/StructureDefinition/ImagingSelection, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/MolecularSequence, http://hl7.org/fhir/StructureDefinition/GenomicStudy). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "DocumentReference": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+              },
+              "ImagingStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+              },
+              "ImagingSelection": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImagingSelection"
+              },
+              "QuestionnaireResponse": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+              },
+              "MolecularSequence": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+              },
+              "GenomicStudy": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/GenomicStudy"
               }
             }
           }
@@ -1499,8 +1184,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        "targets": {
+                          "MolecularSequence": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledQuestionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/ProfiledQuestionnaire.json
@@ -637,8 +637,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -825,8 +827,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -1016,8 +1020,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Questionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/Questionnaire.json
@@ -803,8 +803,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -991,8 +993,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -1182,8 +1186,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/SecondaryTypeRefSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.R5/SchemaSnaps/SecondaryTypeRefSlice.json
@@ -131,8 +131,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -148,8 +150,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -165,8 +169,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+            "targets": {
+              "Communication": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Communication"
+              }
             }
           }
         }
@@ -237,40 +243,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -298,8 +276,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -315,8 +295,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -344,130 +326,39 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  },
-                  {
-                    "name": "forLocation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Location"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Location"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forEndpoint",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Endpoint"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CareTeam, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Group, http://hl7.org/fhir/StructureDefinition/HealthcareService, http://hl7.org/fhir/StructureDefinition/Location, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Endpoint). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
+              },
+              "Location": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Location"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Endpoint": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
               }
             }
           }
@@ -484,110 +375,33 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forPractitionerRole",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PractitionerRole"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forHealthcareService",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "HealthcareService"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
-                    }
-                  },
-                  {
-                    "name": "forEndpoint",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Endpoint"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
-                    }
-                  },
-                  {
-                    "name": "forCareTeam",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CareTeam"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/PractitionerRole, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/HealthcareService, http://hl7.org/fhir/StructureDefinition/Endpoint, http://hl7.org/fhir/StructureDefinition/CareTeam). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "PractitionerRole": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "HealthcareService": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/HealthcareService"
+              },
+              "Endpoint": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Endpoint"
+              },
+              "CareTeam": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CareTeam"
               }
             }
           }
@@ -609,8 +423,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -675,40 +491,12 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "slice": {
-                            "ordered": false,
-                            "defaultAtEnd": false,
-                            "case": [
-                              {
-                                "name": "forDocumentReference",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "DocumentReference"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                                }
-                              },
-                              {
-                                "name": "forTask",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "Task"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/Task"
-                                }
-                              }
-                            ],
-                            "default": {
-                              "issue": {
-                                "issueNumber": 1011,
-                                "severity": "Error",
-                                "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/Task). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                                "type": "Invalid"
-                              }
-                            }
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          },
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
                           }
                         }
                       }
@@ -844,8 +632,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          }
                         }
                       }
                     }
@@ -918,8 +708,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                        "targets": {
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Composition.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Composition.json
@@ -149,8 +149,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -173,8 +175,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -203,60 +207,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -338,50 +300,15 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forPractitioner",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Practitioner"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                        }
-                      },
-                      {
-                        "name": "forOrganization",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Organization"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/Organization). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "Practitioner": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+                  },
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
                   }
                 }
               }
@@ -407,8 +334,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -481,8 +410,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                        "targets": {
+                          "Composition": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Composition"
+                          }
                         }
                       }
                     }
@@ -564,8 +495,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }
@@ -691,8 +624,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                "targets": {
+                  "Resource": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                  }
                 }
               }
             }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Extension.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Extension.json
@@ -386,8 +386,10 @@
                 },
                 {
                   "validate": {
-                    "schema": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                    "targets": {
+                      "Resource": {
+                        "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                      }
                     }
                   }
                 }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Patient.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Patient.json
@@ -333,8 +333,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -474,40 +476,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
               }
             }
           }
@@ -531,8 +505,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -580,40 +556,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/PatternSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/PatternSlice.json
@@ -164,8 +164,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -264,8 +266,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                        "targets": {
+                          "Organization": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                          }
                         }
                       }
                     }
@@ -483,8 +487,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                "targets": {
+                  "Organization": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+                  }
                 }
               }
             }
@@ -603,40 +609,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Practitioner). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
               }
             }
           }
@@ -652,8 +630,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+            "targets": {
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              }
             }
           }
         }
@@ -693,40 +673,12 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forPatient",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Patient"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                        }
-                      },
-                      {
-                        "name": "forRelatedPerson",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "RelatedPerson"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Patient": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                  },
+                  "RelatedPerson": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledFlag.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledFlag.json
@@ -134,55 +134,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
+            "targets": {
+              "Organization": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
                     },
-                    "assertion": {
-                      "anyOf": {
-                        "members": [
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1"
-                          },
-                          {
-                            "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
-                          }
-                        ],
-                        "issue": {
-                          "issueNumber": 1011,
-                          "severity": "Error",
-                          "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
-                          "type": "Invalid"
-                        }
-                      }
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2"
                     }
-                  },
-                  {
-                    "name": "forProcedure",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Procedure"
-                    },
-                    "assertion": {
-                      "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
-                    }
-                  }
-                ],
-                "default": {
+                  ],
                   "issue": {
                     "issueNumber": 1011,
                     "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2, http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure). None of these are profiles on type %INSTANCETYPE% of the resource.",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/ProfiledOrg1, http://validationtest.org/fhir/StructureDefinition/ProfiledOrg2).",
                     "type": "Invalid"
                   }
                 }
+              },
+              "Procedure": {
+                "ref": "http://validationtest.org/fhir/StructureDefinition/ProfiledProcedure"
               }
             }
           }
@@ -203,8 +175,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              }
             }
           }
         }
@@ -219,60 +193,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
               }
             }
           }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledObservation.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledObservation.json
@@ -117,90 +117,27 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCarePlan",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "CarePlan"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-                    }
-                  },
-                  {
-                    "name": "forDeviceRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
-                    }
-                  },
-                  {
-                    "name": "forImmunizationRecommendation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ImmunizationRecommendation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-                    }
-                  },
-                  {
-                    "name": "forMedicationRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "MedicationRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-                    }
-                  },
-                  {
-                    "name": "forNutritionOrder",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "NutritionOrder"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
-                    }
-                  },
-                  {
-                    "name": "forProcedureRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ProcedureRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ProcedureRequest"
-                    }
-                  },
-                  {
-                    "name": "forReferralRequest",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ReferralRequest"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ReferralRequest"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/CarePlan, http://hl7.org/fhir/StructureDefinition/DeviceRequest, http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation, http://hl7.org/fhir/StructureDefinition/MedicationRequest, http://hl7.org/fhir/StructureDefinition/NutritionOrder, http://hl7.org/fhir/StructureDefinition/ProcedureRequest, http://hl7.org/fhir/StructureDefinition/ReferralRequest). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "CarePlan": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+              },
+              "DeviceRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceRequest"
+              },
+              "ImmunizationRecommendation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+              },
+              "MedicationRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+              },
+              "NutritionOrder": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/NutritionOrder"
+              },
+              "ProcedureRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ProcedureRequest"
+              },
+              "ReferralRequest": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ReferralRequest"
               }
             }
           }
@@ -246,21 +183,23 @@
         },
         {
           "validate": {
-            "schema": {
-              "anyOf": {
-                "members": [
-                  {
-                    "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
-                  },
-                  {
-                    "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+            "targets": {
+              "Patient": {
+                "anyOf": {
+                  "members": [
+                    {
+                      "ref": "http://validationtest.org/fhir/StructureDefinition/PatientWithReferences"
+                    },
+                    {
+                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+                    }
+                  ],
+                  "issue": {
+                    "issueNumber": 1011,
+                    "severity": "Error",
+                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
+                    "type": "Invalid"
                   }
-                ],
-                "issue": {
-                  "issueNumber": 1011,
-                  "severity": "Error",
-                  "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://validationtest.org/fhir/StructureDefinition/PatientWithReferences, http://hl7.org/fhir/StructureDefinition/Patient).",
-                  "type": "Invalid"
                 }
               }
             }
@@ -305,40 +244,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forEncounter",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Encounter"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
-                    }
-                  },
-                  {
-                    "name": "forEpisodeOfCare",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "EpisodeOfCare"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Encounter, http://hl7.org/fhir/StructureDefinition/EpisodeOfCare). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              },
+              "EpisodeOfCare": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
               }
             }
           }
@@ -397,60 +308,18 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -639,8 +508,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+            "targets": {
+              "Specimen": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Specimen"
+              }
             }
           }
         }
@@ -655,40 +526,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forDeviceMetric",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "DeviceMetric"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/DeviceMetric). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "DeviceMetric": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
               }
             }
           }
@@ -808,50 +651,15 @@
             },
             {
               "validate": {
-                "schema": {
-                  "slice": {
-                    "ordered": false,
-                    "defaultAtEnd": false,
-                    "case": [
-                      {
-                        "name": "forObservation",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Observation"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                        }
-                      },
-                      {
-                        "name": "forQuestionnaireResponse",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "QuestionnaireResponse"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
-                        }
-                      },
-                      {
-                        "name": "forSequence",
-                        "required": false,
-                        "condition": {
-                          "fhir-type-label": "Sequence"
-                        },
-                        "assertion": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Sequence"
-                        }
-                      }
-                    ],
-                    "default": {
-                      "issue": {
-                        "issueNumber": 1011,
-                        "severity": "Error",
-                        "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Observation, http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse, http://hl7.org/fhir/StructureDefinition/Sequence). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                        "type": "Invalid"
-                      }
-                    }
+                "targets": {
+                  "Observation": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
+                  },
+                  "QuestionnaireResponse": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse"
+                  },
+                  "Sequence": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/Sequence"
                   }
                 }
               }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledQuestionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/ProfiledQuestionnaire.json
@@ -514,8 +514,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -564,8 +566,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/ValueSet"
+                "targets": {
+                  "ValueSet": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/ValueSet"
+                  }
                 }
               }
             }
@@ -805,8 +809,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                        "targets": {
+                          "Resource": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Questionnaire.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/Questionnaire.json
@@ -611,8 +611,10 @@
                         },
                         {
                           "validate": {
-                            "schema": {
-                              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                            "targets": {
+                              "Resource": {
+                                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                              }
                             }
                           }
                         }
@@ -673,8 +675,10 @@
             },
             {
               "validate": {
-                "schema": {
-                  "ref": "http://hl7.org/fhir/StructureDefinition/ValueSet"
+                "targets": {
+                  "ValueSet": {
+                    "ref": "http://hl7.org/fhir/StructureDefinition/ValueSet"
+                  }
                 }
               }
             }
@@ -916,8 +920,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                        "targets": {
+                          "Resource": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/SecondaryTypeRefSlice.json
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.STU3/SchemaSnaps/SecondaryTypeRefSlice.json
@@ -109,40 +109,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPlanDefinition",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "PlanDefinition"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/PlanDefinition"
-                    }
-                  },
-                  {
-                    "name": "forActivityDefinition",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "ActivityDefinition"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/ActivityDefinition"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/PlanDefinition, http://hl7.org/fhir/StructureDefinition/ActivityDefinition). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "PlanDefinition": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/PlanDefinition"
+              },
+              "ActivityDefinition": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/ActivityDefinition"
               }
             }
           }
@@ -158,8 +130,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -174,8 +148,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -235,40 +211,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -284,80 +232,24 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  },
-                  {
-                    "name": "forGroup",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Group"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Group"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/RelatedPerson, http://hl7.org/fhir/StructureDefinition/Group). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+              },
+              "Group": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Group"
               }
             }
           }
@@ -373,8 +265,10 @@
         },
         {
           "validate": {
-            "schema": {
-              "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+            "targets": {
+              "Resource": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Resource"
+              }
             }
           }
         }
@@ -389,40 +283,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forEncounter",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Encounter"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
-                    }
-                  },
-                  {
-                    "name": "forEpisodeOfCare",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "EpisodeOfCare"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Encounter, http://hl7.org/fhir/StructureDefinition/EpisodeOfCare). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Encounter": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Encounter"
+              },
+              "EpisodeOfCare": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
               }
             }
           }
@@ -448,70 +314,21 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forDevice",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Device"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Device"
-                    }
-                  },
-                  {
-                    "name": "forOrganization",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Organization"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
-                    }
-                  },
-                  {
-                    "name": "forPatient",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Patient"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
-                    }
-                  },
-                  {
-                    "name": "forPractitioner",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Practitioner"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
-                    }
-                  },
-                  {
-                    "name": "forRelatedPerson",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "RelatedPerson"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Device, http://hl7.org/fhir/StructureDefinition/Organization, http://hl7.org/fhir/StructureDefinition/Patient, http://hl7.org/fhir/StructureDefinition/Practitioner, http://hl7.org/fhir/StructureDefinition/RelatedPerson). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Device": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Device"
+              },
+              "Organization": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Organization"
+              },
+              "Patient": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Patient"
+              },
+              "Practitioner": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Practitioner"
+              },
+              "RelatedPerson": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
               }
             }
           }
@@ -537,40 +354,12 @@
         },
         {
           "validate": {
-            "schema": {
-              "slice": {
-                "ordered": false,
-                "defaultAtEnd": false,
-                "case": [
-                  {
-                    "name": "forCondition",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Condition"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
-                    }
-                  },
-                  {
-                    "name": "forObservation",
-                    "required": false,
-                    "condition": {
-                      "fhir-type-label": "Observation"
-                    },
-                    "assertion": {
-                      "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
-                    }
-                  }
-                ],
-                "default": {
-                  "issue": {
-                    "issueNumber": 1011,
-                    "severity": "Error",
-                    "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/Condition, http://hl7.org/fhir/StructureDefinition/Observation). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                    "type": "Invalid"
-                  }
-                }
+            "targets": {
+              "Condition": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Condition"
+              },
+              "Observation": {
+                "ref": "http://hl7.org/fhir/StructureDefinition/Observation"
               }
             }
           }
@@ -631,40 +420,12 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "slice": {
-                            "ordered": false,
-                            "defaultAtEnd": false,
-                            "case": [
-                              {
-                                "name": "forDocumentReference",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "DocumentReference"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
-                                }
-                              },
-                              {
-                                "name": "forTask",
-                                "required": false,
-                                "condition": {
-                                  "fhir-type-label": "Task"
-                                },
-                                "assertion": {
-                                  "ref": "http://hl7.org/fhir/StructureDefinition/Task"
-                                }
-                              }
-                            ],
-                            "default": {
-                              "issue": {
-                                "issueNumber": 1011,
-                                "severity": "Error",
-                                "message": "Referenced resource '%RESOURCEURL%' does not validate against any of the expected target profiles (http://hl7.org/fhir/StructureDefinition/DocumentReference, http://hl7.org/fhir/StructureDefinition/Task). None of these are profiles on type %INSTANCETYPE% of the resource.",
-                                "type": "Invalid"
-                              }
-                            }
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          },
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
                           }
                         }
                       }
@@ -790,8 +551,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        "targets": {
+                          "DocumentReference": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                          }
                         }
                       }
                     }
@@ -859,8 +622,10 @@
                     },
                     {
                       "validate": {
-                        "schema": {
-                          "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                        "targets": {
+                          "Task": {
+                            "ref": "http://hl7.org/fhir/StructureDefinition/Task"
+                          }
                         }
                       }
                     }

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/TypeReferenceBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/TypeReferenceBuilderTests.cs
@@ -90,7 +90,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             all.Members.Should().HaveCount(2);
             all.Members[0].Should().BeASchemaAssertionFor(REFERENCE_PROFILE);
             all.Members[1].Should().BeEquivalentTo(
-                new ReferencedInstanceValidator(SchemaReferenceValidator.ForResource),
+                new ReferencedInstanceValidator([new ReferencedInstanceValidator.TargetCase("Resource", SchemaReferenceValidator.ForResource)]),
                 options => options.IncludingAllRuntimeProperties());
         }
 
@@ -163,7 +163,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             all.Members.Should().HaveCount(2);
             all.Members[0].Should().BeASchemaAssertionFor(REFERENCE_PROFILE);
             all.Members[1].Should().BeEquivalentTo(
-                new ReferencedInstanceValidator(new SchemaReferenceValidator(TestProfileArtifactSource.PROFILEDPROCEDURE)),
+                new ReferencedInstanceValidator([new ReferencedInstanceValidator.TargetCase("Procedure", new SchemaReferenceValidator(TestProfileArtifactSource.PROFILEDPROCEDURE))]),
                 options => options.IncludingAllRuntimeProperties());
         }
 
@@ -211,8 +211,10 @@ namespace Firely.Fhir.Validation.Compilation.Tests
             var sch = convert("Reference", targets: new[] { "http://hl7.org/fhir/StructureDefinition/Resource" });
             var all = sch.Should().BeOfType<AllValidator>().Subject;
 
-            all.Members[1].Should().BeOfType<ReferencedInstanceValidator>()
-                .Which.Schema.Should().BeASchemaAssertionFor(SchemaReferenceValidator.ForResource);
+            var targetCase = all.Members[1].Should().BeOfType<ReferencedInstanceValidator>()
+                .Which.TargetCases.Should().ContainSingle().Subject;
+            targetCase.Type.Should().Be("Resource");
+            targetCase.Schema.Should().BeASchemaAssertionFor(SchemaReferenceValidator.ForResource);
         }
 
         [Fact]

--- a/test/Firely.Fhir.Validation.Tests/Impl/BindingValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/BindingValidatorTests.cs
@@ -323,4 +323,74 @@ public class BindingValidatorTests
         result.Errors.Count.Should().Be(0);
         result.Warnings.Count.Should().Be(1);
     }
+
+    [TestMethod]
+    public void NoTerminologyCallWhenConceptsCheckDisabled()
+    {
+        setup(true, null);
+        var validator = new BindingValidator(_bindingAssertion.ValueSetUri,
+            BindingValidator.BindingStrength.Required, true, CodedContentChecks.None);
+
+        // a CodeableConcept without codes would normally violate the required binding's
+        // content rules - but with the Concepts check disabled, nothing is checked at all.
+        var input = new CodeableConcept { Text = "just text" }.ToPocoNode();
+        var result = validator.Validate(input, _validationSettingsM);
+
+        Assert.IsTrue(result.IsSuccessful);
+        _validateCodeService.Verify(vs =>
+            vs.ValueSetValidateCode(It.IsAny<Parameters>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [TestMethod]
+    public void StripsDisplayWhenDisplaysCheckDisabled()
+    {
+        setup(true, null);
+        var validator = new BindingValidator(_bindingAssertion.ValueSetUri,
+            BindingValidator.BindingStrength.Required, true, CodedContentChecks.Concepts);
+
+        var coding = new Coding("http://terminology.hl7.org/CodeSystem/data-absent-reason", "masked", "The Display");
+        var result = validator.Validate(coding.ToPocoNode(), _validationSettingsM);
+
+        Assert.IsTrue(result.IsSuccessful);
+        verify(p => p.Coding != null && p.Coding.Code == "masked" && p.Coding.Display == null);
+
+        // the instance itself must not have been mutated
+        coding.Display.Should().Be("The Display");
+    }
+
+    [TestMethod]
+    public void StripsDisplaysFromCodeableConceptWhenDisplaysCheckDisabled()
+    {
+        setup(true, null);
+        var validator = new BindingValidator(_bindingAssertion.ValueSetUri,
+            BindingValidator.BindingStrength.Required, true, CodedContentChecks.Concepts);
+
+        var concept = new CodeableConcept
+        {
+            Coding =
+            [
+                new Coding("http://sysA", "codeA", "Display A"),
+                new Coding("http://sysB", "codeB", "Display B")
+            ]
+        };
+        var result = validator.Validate(concept.ToPocoNode(), _validationSettingsM);
+
+        Assert.IsTrue(result.IsSuccessful);
+        verify(p => p.CodeableConcept != null && p.CodeableConcept.Coding.Count == 2 &&
+            p.CodeableConcept.Coding.All(c => c.Display == null && c.Code != null));
+
+        concept.Coding.Select(c => c.Display).Should().Equal("Display A", "Display B");
+    }
+
+    [TestMethod]
+    public void KeepsDisplayWithDefaultChecks()
+    {
+        setup(true, null);
+
+        var coding = new Coding("http://terminology.hl7.org/CodeSystem/data-absent-reason", "masked", "The Display");
+        var result = _bindingAssertion.Validate(coding.ToPocoNode(), _validationSettingsM);
+
+        Assert.IsTrue(result.IsSuccessful);
+        verify(p => p.Coding != null && p.Coding.Display == "The Display");
+    }
 }

--- a/test/Firely.Fhir.Validation.Tests/Impl/BindingValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/BindingValidatorTests.cs
@@ -325,6 +325,13 @@ public class BindingValidatorTests
     }
 
     [TestMethod]
+    public void ChecksDefaultsToDefaultWhenOmitted()
+    {
+        var validator = new BindingValidator(_bindingAssertion.ValueSetUri, BindingValidator.BindingStrength.Required, true);
+        validator.Checks.Should().Be(CodedContentChecks.Default);
+    }
+
+    [TestMethod]
     public void NoTerminologyCallWhenConceptsCheckDisabled()
     {
         setup(true, null);

--- a/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
@@ -149,6 +149,27 @@ namespace Firely.Fhir.Validation.Tests
         }
 
         [TestMethod]
+        public void RejectsDuplicateTargetCaseTypes() =>
+            // dispatch always selects the first case per type, so duplicates would be unreachable
+            // (and would break ToJson's per-type "targets" object)
+            Assert.ThrowsException<ArgumentException>(() => new ReferencedInstanceValidator(
+                [new ReferencedInstanceValidator.TargetCase("Patient", SCHEMA), new ReferencedInstanceValidator.TargetCase("Patient", SCHEMA)]));
+
+        [TestMethod]
+        public void CatchAllCaseOnlyAcceptsResources()
+        {
+            // the external resolver in these tests returns a non-resource node for
+            // "http://example.com/hit" - the catch-all "Resource" shortcut must not let it
+            // through the type check
+            validateActor(viaCases("Resource", ReferenceChecks.Exists | ReferenceChecks.TargetType), reference: "http://example.com/hit")
+                .FailedWith("not one of the allowed target types");
+
+            // while a genuine resource target still takes the shortcut
+            validateActor(viaCases("Resource", ReferenceChecks.Exists | ReferenceChecks.TargetType))
+                .Succeeded();
+        }
+
+        [TestMethod]
         public void TypeCheckWithoutProfileValidation()
         {
             // matching type: success, but the case's schema must not have run

--- a/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
@@ -100,12 +100,65 @@ namespace Firely.Fhir.Validation.Tests
         {
             var settings = ValidationSettings.BuildMinimalContext(schemaResolver: new TestResolver() { SCHEMA });
             settings.ResolveExternalReference = resolve;
-            
+
             var instance = new CodeableReference { Reference = new ResourceReference("http://example.com/hit") };
             var validator = via();
             var result = validator.Validate(instance.ToPocoNode(), settings);
 
             result.SucceededWith("Validation was triggered");
+        }
+
+        private static ReferencedInstanceValidator viaCases(string type, ReferenceChecks checks = ReferenceChecks.All) =>
+            new([new ReferencedInstanceValidator.TargetCase(type, SCHEMA)], checks: checks);
+
+        private static ResultReport validateActor(ReferencedInstanceValidator testee, string reference = "#p1")
+        {
+            var vc = ValidationSettings.BuildMinimalContext(schemaResolver: new TestResolver() { SCHEMA });
+            vc.ResolveExternalReference = resolve;
+
+            var actor = CreateInstance(reference).ToPocoNode().NavigateTo("entry.resource.participant.actor").Single();
+            return testee.Validate(actor, vc);
+        }
+
+        [TestMethod]
+        public void ValidatesTargetAgainstMatchingTypeCase() =>
+            // "#p1" resolves to the contained Practitioner, which matches the case's type
+            validateActor(viaCases("Practitioner")).SucceededWith("Validation was triggered");
+
+        [TestMethod]
+        public void AbstractBaseTypeCaseMatchesDerivedTarget() =>
+            // a case for "Resource" (an "any" reference) matches every resource type
+            validateActor(viaCases("Resource")).SucceededWith("Validation was triggered");
+
+        [TestMethod]
+        public void ReportsTypeMismatchWhenNoCaseMatches() =>
+            validateActor(viaCases("Patient")).FailedWith("not one of the allowed target types");
+
+        [TestMethod]
+        public void ExistsCheckOnlyResolvesWithoutValidatingTarget()
+        {
+            // even a non-matching type case is not reported: only resolution is checked
+            var result = validateActor(viaCases("Patient", ReferenceChecks.Exists));
+
+            Assert.IsTrue(result.IsSuccessful);
+            Assert.IsFalse(result.Evidence.OfType<IssueAssertion>().Any(), "no target validation should have run");
+
+            // but an unresolvable reference is still reported
+            validateActor(viaCases("Patient", ReferenceChecks.Exists), reference: "#p2")
+                .SucceededWith("Cannot resolve reference");
+        }
+
+        [TestMethod]
+        public void TypeCheckWithoutProfileValidation()
+        {
+            // matching type: success, but the case's schema must not have run
+            var result = validateActor(viaCases("Practitioner", ReferenceChecks.Exists | ReferenceChecks.TargetType));
+            Assert.IsTrue(result.IsSuccessful);
+            Assert.IsFalse(result.Evidence.OfType<IssueAssertion>().Any(), "the target profile should not have been validated");
+
+            // non-matching type: the type error is still reported
+            validateActor(viaCases("Patient", ReferenceChecks.Exists | ReferenceChecks.TargetType))
+                .FailedWith("not one of the allowed target types");
         }
     }
 }

--- a/test/Firely.Fhir.Validation.Tests/Impl/SeverityOverrideTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/SeverityOverrideTests.cs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026, Firely (info@fire.ly) and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://github.com/FirelyTeam/firely-validator-api/blob/main/LICENSE
+ */
+
+using FluentAssertions;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Support;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Firely.Fhir.Validation.Tests
+{
+    [TestClass]
+    public class SeverityOverrideTests
+    {
+        private static readonly ValidationSettings SETTINGS = ValidationSettings.BuildMinimalContext();
+
+        // A failing input for every concrete InvariantValidator implementation, so a severity
+        // override is proven to work on the generic FhirPath validator AND the hand-coded
+        // fast-path validators alike.
+        private static IEnumerable<(InvariantValidator validator, PocoNode failingInput)> failingCases()
+        {
+            yield return (new FhirPathValidator("test-1", "false"), new HumanName { Given = ["a"] }.ToPocoNode());
+            yield return (new FhirEle1Validator(), new HumanName().ToPocoNode());
+            yield return (new FhirExt1Validator(), new Extension().ToPocoNode());
+            yield return (new FhirTxt1Validator(), new HumanName().ToPocoNode());
+            yield return (new FhirTxt2Validator(), PocoNode.ForPrimitive<FhirString>(" "));
+        }
+
+        [TestMethod]
+        public void OverrideDowngradesFailingInvariantsToWarnings()
+        {
+            foreach (var (validator, input) in failingCases())
+            {
+                var name = validator.GetType().Name;
+
+                // without the override, the invariant fails with the error-constraint issue
+                var original = ((IValidatable)validator).Validate(input, SETTINGS, new ValidationState());
+                original.IsSuccessful.Should().BeFalse($"{name} should fail on its failing input");
+                original.GetIssues().Single().IssueNumber.Should()
+                    .Be(Issue.CONTENT_ELEMENT_FAILS_ERROR_CONSTRAINT.Code, $"{name} should report an error constraint");
+
+                // 'with' produces a copy of the same concrete type, carrying the override
+                var downgraded = validator with { SeverityOverride = OperationOutcome.IssueSeverity.Warning };
+                downgraded.GetType().Should().Be(validator.GetType());
+
+                // the downgraded invariant emits the warning-constraint issue, flipping the outcome
+                var result = ((IValidatable)downgraded).Validate(input, SETTINGS, new ValidationState());
+                result.IsSuccessful.Should().BeTrue($"{name} with a warning override should not fail validation");
+                result.GetIssues().Single().IssueNumber.Should()
+                    .Be(Issue.CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT.Code, $"{name} should report a warning constraint");
+            }
+        }
+
+        [TestMethod]
+        public void OverrideTakesPrecedenceOverBestPracticeMapping()
+        {
+            // for a best-practice invariant, the effective severity normally comes from the
+            // ConstraintBestPractices setting - an explicit override must win over that too
+            var bestPractice = new FhirPathValidator("bp-1", "false", "a best practice", OperationOutcome.IssueSeverity.Warning, bestPractice: true);
+            var settings = ValidationSettings.BuildMinimalContext();
+            settings.ConstraintBestPractices = ValidateBestPracticesSeverity.Error;
+
+            var input = new HumanName { Given = ["a"] }.ToPocoNode();
+
+            ((IValidatable)bestPractice).Validate(input, settings, new ValidationState())
+                .IsSuccessful.Should().BeFalse("the best-practice setting escalates the invariant to an error");
+
+            var downgraded = bestPractice with { SeverityOverride = OperationOutcome.IssueSeverity.Warning };
+            var result = ((IValidatable)downgraded).Validate(input, settings, new ValidationState());
+            result.IsSuccessful.Should().BeTrue("the override wins over the best-practice mapping");
+            result.GetIssues().Single().IssueNumber.Should().Be(Issue.CONTENT_ELEMENT_FAILS_WARNING_CONSTRAINT.Code);
+        }
+    }
+}

--- a/test/Firely.Fhir.Validation.Tests/Impl/SeverityOverrideTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/SeverityOverrideTests.cs
@@ -59,6 +59,26 @@ namespace Firely.Fhir.Validation.Tests
         }
 
         [TestMethod]
+        public void EqualityIgnoresCompilationCache()
+        {
+            var a = new FhirPathValidator("test-1", "true");
+            var b = new FhirPathValidator("test-1", "true");
+
+            a.Equals(b).Should().BeTrue();
+            var hash = a.GetHashCode();
+
+            // validating compiles and caches the expression inside the validator - being a record,
+            // its equality and hash code must nevertheless remain stable
+            _ = ((IValidatable)a).Validate(new HumanName { Given = ["a"] }.ToPocoNode(), SETTINGS, new ValidationState());
+
+            a.Equals(b).Should().BeTrue();
+            a.GetHashCode().Should().Be(hash);
+
+            // while a semantic difference (like a severity override) does make them unequal
+            (a with { SeverityOverride = OperationOutcome.IssueSeverity.Warning }).Equals(b).Should().BeFalse();
+        }
+
+        [TestMethod]
         public void OverrideTakesPrecedenceOverBestPracticeMapping()
         {
             // for a best-practice invariant, the effective severity normally comes from the


### PR DESCRIPTION
Second batch of groundwork for the [Advisor Framework](https://confluence.hl7.org/spaces/FHIR/pages/281216179/Validator+Advisor+Framework) redesign in the enterprise validator, building on #680. All changes are on `[Experimental]` types and preserve default behavior (with two deliberate improvements, called out below) — the advisor rules will later configure these options by rebuilding validators with non-default values.

## Changes

### `BindingValidator`: selectable coded-content checks
New `CodedContentChecks` flags (`Concepts | Displays | Status`, default = both current checks) with an extended constructor:
- `Concepts` cleared ⇒ the coded content is not checked at all — including skipping the (expensive) terminology-service call.
- `Displays` cleared ⇒ the display texts are omitted from the `$validate-code` parameters (on a copy — the instance is never mutated), so the terminology service cannot validate them. Omission is the operation's own mechanism for this ("If no display is provided, the server cannot validate the display value"); `Displays` therefore only has effect while `Concepts` is enabled.
- `Status` is accepted so configurations mentioning it can round-trip, but is not implementable with the current terminology-service interface (documented on the member).

### `ReferencedInstanceValidator`: native type dispatch for reference targets
The type dispatch that was encoded as a generated `SliceValidator` with `FhirTypeLabelValidator` discriminators *inside the target schema* is now a first-class feature of the validator itself:
- `TargetCases` — a list of (target type → profile schema) cases, matched against the resolved target by exact type name and then base-type-aware (so a `Reference(Any)`, carried as a `Resource` case, matches every resource).
- `ReferenceChecks` flags (`Exists | TargetType | TargetProfile`, default all): `Exists` resolves and reports unresolvable references; `TargetType` requires the target to match a case; `TargetProfile` validates it against the matching case's schema. Checks on the reference *value* (parseability, aggregation, versioning) always run.
- `TypeReferenceBuilder` supplies the cases and no longer generates the pseudo-slicing (`buildLabelledChoice` is gone). The single-schema constructor remains for untyped targets.

**Deliberate behavioral improvements:**
1. *Single-target-type references are now actually type-checked.* Previously `Reference(Patient)` pointing at a Group produced confusing profile-mismatch noise; now it produces one clear "not one of the allowed target types" error.
2. *Cleaner error output.* Reference-target errors no longer carry artificial `(for slice forX)` suffixes / `[forX]` trace decorations, and duplicated errors that differed only by that slice context now deduplicate. Real (profile-defined) slices keep their slice context.

Schema dumps shrink accordingly: reference targets render as a compact `"targets"` map instead of a generated slicing (the regenerated SchemaSnaps in this PR remove ~3600 more lines than they add).

### `InvariantValidator` hierarchy → records with a severity override
All five invariant validators (the FhirPath one and the four hand-coded fast paths) are now records, so a modified copy can be made polymorphically with `with { }`. The new init-only `SeverityOverride` takes precedence over both the declared severity *and* the best-practice mapping, and produces the matching warning/error-constraint issue (correct issue number, correct outcome flip). Overrides are rendered by `ToJson()`, so a schema rewritten by advisor rules stays self-describing.

Build note: the compiler synthesizes covariant `Clone` methods on net8.0 but not netstandard2.1, so those five members are declared in target-framework-specific `PublicAPI/{tfm}/PublicAPI.Unshipped.txt` files, wired via conditional `AdditionalFiles`.

## Regenerated artifacts
- **SchemaSnaps** (all four versions) via `OverwriteSchemaSnaps`.
- **FhirTestCases `manifest.json`** via `AddFirelySdkValidatorResults`, run from all four version projects. ⚠️ This lives in the `FhirTestCases` **submodule**: this PR bumps the submodule to branch [`advisor-groundwork-phase2-v2`](https://github.com/FirelyTeam/fhir-test-cases/tree/advisor-groundwork-phase2-v2) (one commit on top of the current develop pointer) — that submodule commit should be merged/kept when this PR merges.
- **issue-165 expected output** — regenerating against the rebased code produced no further changes on top of develop's current baseline.

## Tests
New: `SeverityOverrideTests` (all five subclasses + best-practice precedence), 4 `BindingValidatorTests` (no terminology call when concepts disabled; display stripping for Coding/CodeableConcept incl. no-mutation check; default keeps displays), 5 `ReferencedInstanceValidatorTests` (case match, abstract-base match, type mismatch, exists-only, type-without-profile). `TypeReferenceBuilderTests` updated to the target-case shape. All suites green after rebasing onto develop (core 279, R4 491, STU3 165, R4B 124, R5 319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aNDhb2JBMjnYzfqxeWTs5
