### PR TITLE
VONK-10051: Fix named-elements validation being ran at parent rather than the child 

### DIFF
--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilder.cs
@@ -198,11 +198,16 @@ public class SchemaBuilder : ISchemaBuilder
 
             var schemaMembers = convert(nav, conversionMode);
 
+            // Is *this* element a named-elements extension carrier? If so, its *own* children set must
+            // be open and its own schema is where NamedExtensionsValidator belongs - see the comments
+            // where that validator is added below.
+            bool isNamedElementsCarrier = nav.IsNamedElementsCarrier();
+
             // Children need special treatment since the definition of this assertion does not
             // depend on the current ElementNode, but on its descendants in the ElementDefNavigator.
             if (nav.HasChildren)
             {
-                var childrenAssertion = createChildrenAssertion(nav, subschemas, out var valueAssertion, out var requiredAssertion, out var hasNamedElementsChild);
+                var childrenAssertion = createChildrenAssertion(nav, subschemas, isNamedElementsCarrier, out var valueAssertion, out var requiredAssertion);
 
                 // A repeating logical-model element rendered as a JSON object keyed by a sibling
                 // child's value (json-property-key), instead of a JSON array - e.g. CDS Hooks'
@@ -240,17 +245,16 @@ public class SchemaBuilder : ISchemaBuilder
                         schemaMembers.Add(requiredAssertion);
                     schemaMembers.Add(childrenAssertion);
 
-                    // One of this element's own children is a named-elements extension carrier (e.g.
-                    // fhirAuthorization.extension typed CDSHooksExtensions) - its named extensions
-                    // (davinci-crd.version, etc.) are rendered directly on THIS element, not nested
-                    // under a literal "extension" key, so createChildrenAssertion already folded
-                    // AllowAdditionalChildren=true into childrenAssertion above and omitted "extension"
-                    // from its ChildList. NamedExtensionsValidator resolves each of those unforeseen
-                    // names to its defining StructureDefinition via the runtime-supplied
+                    // This element itself is the named-elements extension carrier (e.g.
+                    // fhirAuthorization.extension), so the named extensions (davinci-crd.version, etc.)
+                    // appear as *its* children in the instance. createChildrenAssertion has already
+                    // folded AllowAdditionalChildren=true into childrenAssertion above, and
+                    // NamedExtensionsValidator resolves each of those unforeseen names to its defining
+                    // StructureDefinition via the runtime-supplied
                     // ValidationSettings.ConformanceResourceResolver and validates the value against
                     // it - anything declared in childrenAssertion.ChildList is a regular (known)
                     // child, not a named extension.
-                    if (hasNamedElementsChild)
+                    if (isNamedElementsCarrier)
                         schemaMembers.Add(new NamedExtensionsValidator(childrenAssertion.ChildList.Keys));
 
                     // This is a temporary hack for the issue where snapshot generator won't copy the invariants from base when pulling all children into the ElementDefinitionNavigator.
@@ -265,6 +269,15 @@ public class SchemaBuilder : ISchemaBuilder
                         schemaMembers.Add(new BaseTypeInvariantConstraintsValidator());
                     }
                 }
+            }
+
+            else if (isNamedElementsCarrier)
+            {
+                // A carrier normally declares no children at all - its members are named extensions,
+                // not elements of the profile. Without a ChildrenValidator nothing constrains which
+                // children may appear (which is exactly right here), so all that is needed is the
+                // validator resolving every member found on the instance as a named extension.
+                schemaMembers.Add(new NamedExtensionsValidator([]));
             }
 
             // Slicing also needs to navigate to its sibling ElementDefinitions,
@@ -347,7 +360,8 @@ public class SchemaBuilder : ISchemaBuilder
     private ChildrenValidator createChildrenAssertion(
         ElementDefinitionNavigator parent,
         SubschemaCollector? subschemas,
-        out IAssertion? valueAssertion, out IAssertion? requiredAssertion, out bool hasNamedElementsChild)
+        bool isNamedElementsCarrier,
+        out IAssertion? valueAssertion, out IAssertion? requiredAssertion)
     {
         // Recurse into children, make sure we do that on a (shallow) copy of
         // the navigator.
@@ -369,13 +383,12 @@ public class SchemaBuilder : ISchemaBuilder
         bool allowAdditionalChildren = (!atTypeRoot && parentElementDef.IsResourcePlaceholder()) ||
                                        (atTypeRoot && parent.StructureDefinition.Abstract == true);
 
-        var children = harvestChildren(childNav, subschemas, out valueAssertion, out requiredAssertion, out hasNamedElementsChild);
+        var children = harvestChildren(childNav, subschemas, out valueAssertion, out requiredAssertion);
 
-        // A named-elements extension carrier among this element's children (e.g. fhirAuthorization's
-        // own "extension" child, typed CDSHooksExtensions) means its named extensions are rendered
-        // directly on THIS element in the wire format, not nested under a literal "extension" key -
-        // so THIS element's own children set must accept those unforeseen names too.
-        if (hasNamedElementsChild)
+        // This element is a named-elements extension carrier: besides whatever children it declares,
+        // its instance carries named extensions (davinci-crd.version, etc.) that no profile declares
+        // as children, so its own children set must accept those unforeseen names.
+        if (isNamedElementsCarrier)
             allowAdditionalChildren = true;
 
         return new ChildrenValidator(children, allowAdditionalChildren);
@@ -385,14 +398,12 @@ public class SchemaBuilder : ISchemaBuilder
         ElementDefinitionNavigator childNav,
         SubschemaCollector? subschemas,
         out IAssertion? valueAssertion,
-        out IAssertion? requiredAssertion,
-        out bool hasNamedElementsChild
+        out IAssertion? requiredAssertion
     )
     {
         var children = new Dictionary<string, IAssertion>();
         var requiredChildren = new List<string>();
         valueAssertion = null;
-        hasNamedElementsChild = false;
 
         var isLogical = childNav.StructureDefinition.Kind == StructureDefinition.StructureDefinitionKind.Logical;
 
@@ -400,16 +411,6 @@ public class SchemaBuilder : ISchemaBuilder
 
         do
         {
-            // A named-elements extension carrier (extension-style = named-elements) has no literal
-            // JSON property of its own - its named extensions (davinci-crd.version, etc.) appear
-            // directly as siblings of this child in the parent object. So it contributes no entry to
-            // the children dictionary; instead it flags the parent's ChildrenValidator as open.
-            if (isLogical && childNav.Current?.GetExtensionStyle() == "named-elements")
-            {
-                hasNamedElementsChild = true;
-                continue;
-            }
-
             var childPath = childNav.Current?.Base?.Path is { } basePath
                 ? trimPath(basePath)
                 : trimPath(childNav.Path);

--- a/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/SchemaBuilders/TypeReferenceBuilder.cs
@@ -83,6 +83,14 @@ namespace Firely.Fhir.Validation.Compilation
             if (def.HasTypeSpecifier() || def.HasImpliedStringPrefix())
                 yield break;
 
+            // A named-elements extension carrier (extension-style = named-elements, e.g. CDS Hooks/CRD's
+            // fhirAuthorization.extension) is a JSON object whose members are named extensions, each
+            // resolved and validated at runtime by NamedExtensionsValidator (see SchemaBuilder). Its
+            // declared type only names the "bag of extensions" placeholder type, whose own schema closes
+            // its children set and would therefore reject every named extension actually on the wire.
+            if (nav.IsNamedElementsCarrier())
+                yield break;
+
             if (shouldValidateTypeReference(nav))
             {
                 var typeAssertion = ConvertTypeReferences(def.Type);

--- a/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
+++ b/src/Firely.Fhir.Validation.Compilation.Shared/ToolsExtensions.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Specification.Navigation;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -27,6 +28,7 @@ internal static class ToolsExtensions
     private const string TYPE_SPECIFIER = "http://hl7.org/fhir/tools/StructureDefinition/type-specifier";
     private const string IMPLIED_STRING_PREFIX = "http://hl7.org/fhir/tools/StructureDefinition/implied-string-prefix";
     private const string JSON_NULLABLE = "http://hl7.org/fhir/tools/StructureDefinition/json-nullable";
+    private const string NAMED_ELEMENTS = "named-elements";
     private const string TYPE_SPECIFIER_CONDITION = "condition";
     private const string TYPE_SPECIFIER_TYPE = "type";
 
@@ -43,6 +45,20 @@ internal static class ToolsExtensions
     /// </summary>
     internal static string? GetExtensionStyle(this ElementDefinition ed) =>
         ed.GetPrimitiveExtensionValue(EXTENSION_STYLE) ?? ed.GetPrimitiveExtensionValue(EXTENSION_STYLE_LEGACY);
+
+    /// <summary>
+    /// Whether the element the navigator is on is a named-elements extension carrier: a JSON object
+    /// whose members are IG-specific named extensions (e.g. <c>davinci-crd.version</c>) instead of
+    /// children declared by the profile.
+    /// </summary>
+    /// <remarks>The carrier is a real, nested property on the wire - e.g. CDS Hooks/CRD's
+    /// <c>"fhirAuthorization": { "access_token": ..., "extension": { "davinci-crd.version": ... } }</c> -
+    /// so its own children set is the open one, and its own schema is where
+    /// <c>NamedExtensionsValidator</c> belongs (see <c>SchemaBuilder</c>). Guarded on
+    /// <c>Kind == Logical</c> so FHIR resource/datatype schemas are unaffected.</remarks>
+    internal static bool IsNamedElementsCarrier(this ElementDefinitionNavigator nav) =>
+        nav.StructureDefinition?.Kind == StructureDefinition.StructureDefinitionKind.Logical &&
+        nav.Current?.GetExtensionStyle() == NAMED_ELEMENTS;
 
     /// <summary>
     /// The name of the sibling child element whose value should be used as the JSON object key when this

--- a/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
+++ b/test/Firely.Fhir.Validation.Compilation.Tests.Shared/SchemaBuilders/LogicalModelBuilderTests.cs
@@ -8,6 +8,7 @@
 using FluentAssertions;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Navigation;
+using Hl7.Fhir.Specification.Source;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -25,6 +26,7 @@ namespace Firely.Fhir.Validation.Compilation.Tests
         private const string IMPLIED_STRING_PREFIX = TOOLS + "implied-string-prefix";
         private const string JSON_NULLABLE = TOOLS + "json-nullable";
         private const string ID_EXPECTATION = TOOLS + "id-expectation";
+        private const string EXTENSION_STYLE = TOOLS + "extension-style";
 
         private readonly SchemaBuilderFixture _fixture;
 
@@ -253,6 +255,145 @@ namespace Firely.Fhir.Validation.Compilation.Tests
 
             // The element is a single JSON object, so counting its occurrences would be meaningless.
             members.OfType<CardinalityValidator>().Should().BeEmpty();
+        }
+
+
+        // --- extension-style = named-elements ------------------------------------------------------
+
+        private static ElementDefinition typedMember(string path, string typeCode, params Extension[] extensions)
+        {
+            var def = new ElementDefinition(path) { Min = 0, Max = "1" };
+            def.Type.Add(new ElementDefinition.TypeRefComponent { Code = typeCode });
+            def.Extension.AddRange(extensions);
+            return def;
+        }
+
+        private static ElementDefinition carrier(string path, string typeCode = "CodeableConcept") =>
+            typedMember(path, typeCode, new Extension(EXTENSION_STYLE, new Code("named-elements")));
+
+        // A named-elements carrier is a real, nested JSON object on the wire (CDS Hooks/CRD render e.g.
+        // "fhirAuthorization": { "access_token": ..., "extension": { "davinci-crd.version": ... } }), so
+        // it must show up as an ordinary child of its parent, with a closed children set on the parent.
+        [Fact]
+        public void NamedElementsCarrierIsARegularChildOfItsParent()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                typedMember("Model.active", "boolean"),
+                carrier("Model.maritalStatus"));
+
+            var members = convertElement(sd);
+
+            var children = members.OfType<ChildrenValidator>().Should().ContainSingle().Subject;
+            children.ChildList.Keys.Should().BeEquivalentTo(["active", "maritalStatus"]);
+            children.AllowAdditionalChildren.Should().BeFalse("the named extensions live inside the carrier, not next to it");
+            members.OfType<NamedExtensionsValidator>().Should().BeEmpty("the parent has no named extensions of its own");
+        }
+
+        // The named extensions appear as children of the carrier itself, so that is where the open
+        // children set and the NamedExtensionsValidator belong.
+        [Fact]
+        public void NamedElementsCarrierValidatesItsOwnChildrenAsNamedExtensions()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                carrier("Model.maritalStatus"));
+
+            var members = convertElement(sd, "Model.maritalStatus");
+
+            // No ChildrenValidator at all: with no declared children there is nothing to constrain,
+            // and an empty-but-open one would be a no-op.
+            members.OfType<ChildrenValidator>().Should().BeEmpty();
+            members.OfType<NamedExtensionsValidator>().Should().ContainSingle()
+                .Which.KnownChildNames.Should().BeEmpty("a carrier without declared children has no known child names");
+
+            // The declared type is just a placeholder for "bag of named extensions" - validating against
+            // its (closed) schema would reject every named extension actually on the wire.
+            members.OfType<SchemaReferenceValidator>().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void DeclaredChildrenOfACarrierRemainKnownChildren()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                carrier("Model.maritalStatus"),
+                typedMember("Model.maritalStatus.text", "string"));
+
+            var members = convertElement(sd, "Model.maritalStatus");
+
+            var children = members.OfType<ChildrenValidator>().Should().ContainSingle().Subject;
+            children.ChildList.Keys.Should().BeEquivalentTo(["text"]);
+            children.AllowAdditionalChildren.Should().BeTrue();
+            members.OfType<NamedExtensionsValidator>().Should().ContainSingle()
+                .Which.KnownChildNames.Should().BeEquivalentTo(["text"]);
+        }
+
+        [Fact]
+        public void ExtensionStyleIsIgnoredOutsideLogicalModels()
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.ComplexType,
+                new ElementDefinition("Model"),
+                carrier("Model.maritalStatus"));
+
+            convertElement(sd, "Model.maritalStatus").OfType<NamedExtensionsValidator>().Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// Resolves named extension names (which are not canonicals at all) to StructureDefinitions, the
+        /// way a runtime host (e.g. an IG-aware server) is expected to.
+        /// </summary>
+        private class NamedExtensionResolver(Dictionary<string, string> nameToProfile) : IAsyncResourceResolver
+        {
+            public System.Threading.Tasks.Task<Resource?> ResolveByCanonicalUriAsync(string uri) =>
+                System.Threading.Tasks.Task.FromResult<Resource?>(
+                    nameToProfile.TryGetValue(uri, out var url) ? new StructureDefinition { Url = url } : null);
+
+            public System.Threading.Tasks.Task<Resource?> ResolveByUriAsync(string uri) => ResolveByCanonicalUriAsync(uri);
+        }
+
+        // End-to-end: a logical model with a carrier child, compiled to a schema and run against an
+        // instance whose named extension is nested *inside* the carrier - the shape actually seen on the
+        // wire (see e.g. https://crd.davinci.hl7.org/r4/cds-services). CodeableConcept.text stands in for
+        // a named extension here (as in KeyedObjectValidatorTests, a POCO provides the node shape).
+        private ResultReport validateCarrierInstance(Dictionary<string, string> resolvableNames)
+        {
+            var sd = model(StructureDefinition.StructureDefinitionKind.Logical,
+                new ElementDefinition("Model"),
+                typedMember("Model.active", "boolean"),
+                carrier("Model.maritalStatus"));
+
+            var schema = new ElementSchema("http://example.org/Model", convertElement(sd));
+
+            var instance = new Patient
+            {
+                Active = true,
+                MaritalStatus = new CodeableConcept { Text = "urn:example:whatever" }
+            };
+
+            var settings = _fixture.NewValidationSettings();
+            settings.ConformanceResourceResolver = new NamedExtensionResolver(resolvableNames);
+
+            return schema.Validate(instance.ToPocoNode(), settings);
+        }
+
+        [Fact]
+        public void NamedExtensionNestedInTheCarrierValidatesAgainstItsResolvedProfile()
+        {
+            var result = validateCarrierInstance(new() { ["text"] = Canonical.ForCoreType("string").ToString() });
+
+            result.Errors.Should().BeEmpty();
+            result.IsSuccessful.Should().BeTrue();
+        }
+
+        [Fact]
+        public void UnresolvableNamedExtensionInTheCarrierStillFails()
+        {
+            var result = validateCarrierInstance([]);
+
+            result.IsSuccessful.Should().BeFalse();
+            // Note the name reported is the named extension inside the carrier, not the carrier itself.
+            result.Errors.Should().ContainSingle().Which.Message.Should().Contain("'text'");
         }
 
         // --- id-expectation -----------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces comprehensive support for "named-elements" extension carriers in logical models within the FHIR validation schema builder. The changes ensure that elements marked as named-elements extension carriers are handled correctly during schema compilation and validation, aligning with how such extensions are represented and validated in real-world FHIR instances. The update includes both core logic changes and extensive new tests to verify correct handling and validation of named-elements extension carriers.

**Support for named-elements extension carriers:**

* Added the `IsNamedElementsCarrier` extension method to `ElementDefinitionNavigator`, allowing the schema builder to detect when an element is a named-elements extension carrier. This is based on the `"extension-style"` extension being set to `"named-elements"` and the structure kind being logical.
* Updated the schema builder logic in `SchemaBuilder.cs` so that when an element is a named-elements carrier:
  * Its own children set is open, and a `NamedExtensionsValidator` is attached at the correct schema level.
  * The logic for determining when to allow additional children and where to attach the validator is now based on whether the element itself is a carrier, not on its children.
* Ensured that type reference validation is skipped for named-elements carriers, as their declared type is merely a placeholder for a bag of extensions. 

**Test coverage for named-elements extension carriers:**

* Added extensive tests in `LogicalModelBuilderTests.cs` to cover:
  * The correct placement and behavior of `NamedExtensionsValidator` and `ChildrenValidator` for carriers and their parents.
  * The handling of declared children on carriers.
  * The correct behavior when the extension-style is used outside logical models.
  * End-to-end validation scenarios, including correct resolution of named extensions and error handling for unresolvable extensions.

**Supporting code and documentation:**

* Added helper methods and constants to simplify creating test cases for named-elements extension carriers. 
* Improved code comments and documentation throughout the new and modified methods to clarify the intended behavior and rationale. 

**Other minor changes:**

* Added a missing import for `Hl7.Fhir.Specification.Navigation` in `ToolsExtensions.cs` and `LogicalModelBuilderTests.cs` to support the new extension method.
* Added the `NAMED_ELEMENTS` constant for clarity and maintainability. 

These changes ensure the schema builder and validator can correctly handle logical model elements that act as carriers for named extensions, matching the expectations of FHIR implementation guides and real-world data.