### PR TITLE
Let the single-schema ReferencedInstanceValidator carry reduced checks

### DIFF
--- a/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
+++ b/src/Firely.Fhir.Validation/Impl/ReferencedInstanceValidator.cs
@@ -147,14 +147,20 @@ namespace Firely.Fhir.Validation
         /// Create a <see cref="ReferencedInstanceValidator"/> that validates every target against
         /// a single schema, without checking the target's type.
         /// </summary>
+        /// <remarks>Since this form declares no target types,
+        /// <see cref="ReferenceChecks.TargetType"/> has nothing to check and is inert here;
+        /// <see cref="ReferenceChecks.TargetProfile"/> selects whether the target is validated
+        /// against <paramref name="schema"/>.</remarks>
 #pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
         public ReferencedInstanceValidator(IAssertion schema,
-            IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null)
+            IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null,
+            ReferenceChecks checks = ReferenceChecks.All)
 #pragma warning restore RS0026
         {
             Schema = schema ?? throw new ArgumentNullException(nameof(schema));
             AggregationRules = aggregationRules?.ToArray();
             VersioningRules = versioningRules;
+            Checks = checks;
         }
 
         /// <summary>
@@ -446,10 +452,12 @@ namespace Firely.Fhir.Validation
         /// </summary>
         private ResultReport validateTarget(string reference, PocoNode target, ValidationSettings vc, ValidationState state)
         {
-            // The legacy single-schema form does no type checking of its own, and can only be
-            // constructed with Checks == All, so the target is always validated against the schema.
+            // The single-schema form declares no target types, so there is nothing for TargetType to
+            // check; only TargetProfile decides whether the target is validated against the schema.
             if (TargetCases is null)
-                return Schema!.ValidateOne(target, vc, state);
+                return Checks.HasFlag(ReferenceChecks.TargetProfile)
+                    ? Schema!.ValidateOne(target, vc, state)
+                    : ResultReport.SUCCESS;
 
             if (!Checks.HasFlag(ReferenceChecks.TargetType) && !Checks.HasFlag(ReferenceChecks.TargetProfile))
                 return ResultReport.SUCCESS;

--- a/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
+++ b/src/Firely.Fhir.Validation/PublicAPI.Unshipped.txt
@@ -264,7 +264,7 @@ Firely.Fhir.Validation.ReferencedInstanceValidator
 Firely.Fhir.Validation.ReferencedInstanceValidator.AggregationRules.get -> System.Collections.Generic.IReadOnlyCollection<Firely.Fhir.Validation.AggregationMode>?
 Firely.Fhir.Validation.ReferencedInstanceValidator.Checks.get -> Firely.Fhir.Validation.ReferenceChecks
 Firely.Fhir.Validation.ReferencedInstanceValidator.HasAggregation.get -> bool
-Firely.Fhir.Validation.ReferencedInstanceValidator.ReferencedInstanceValidator(Firely.Fhir.Validation.IAssertion! schema, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.AggregationMode>? aggregationRules = null, Firely.Fhir.Validation.ReferenceVersionRules? versioningRules = null) -> void
+Firely.Fhir.Validation.ReferencedInstanceValidator.ReferencedInstanceValidator(Firely.Fhir.Validation.IAssertion! schema, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.AggregationMode>? aggregationRules = null, Firely.Fhir.Validation.ReferenceVersionRules? versioningRules = null, Firely.Fhir.Validation.ReferenceChecks checks = Firely.Fhir.Validation.ReferenceChecks.All) -> void
 Firely.Fhir.Validation.ReferencedInstanceValidator.ReferencedInstanceValidator(System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase!>! targetCases, System.Collections.Generic.IEnumerable<Firely.Fhir.Validation.AggregationMode>? aggregationRules = null, Firely.Fhir.Validation.ReferenceVersionRules? versioningRules = null, Firely.Fhir.Validation.ReferenceChecks checks = Firely.Fhir.Validation.ReferenceChecks.All) -> void
 Firely.Fhir.Validation.ReferencedInstanceValidator.Schema.get -> Firely.Fhir.Validation.IAssertion?
 Firely.Fhir.Validation.ReferencedInstanceValidator.TargetCase

--- a/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
+++ b/test/Firely.Fhir.Validation.Tests/Impl/ReferencedInstanceValidatorTests.cs
@@ -45,7 +45,8 @@ namespace Firely.Fhir.Validation.Tests
             yield return [CreateInstance("http://example.com/xhit"), via(), true, "Cannot resolve reference"];
         }
 
-        private static ReferencedInstanceValidator via(AggregationMode[]? agg = null, ReferenceVersionRules? ver = null) => new(SCHEMA, agg, ver);
+        private static ReferencedInstanceValidator via(AggregationMode[]? agg = null, ReferenceVersionRules? ver = null,
+            ReferenceChecks checks = ReferenceChecks.All) => new(SCHEMA, agg, ver, checks);
         
         public static Bundle CreateInstance(string reference) =>
             new()
@@ -180,6 +181,33 @@ namespace Firely.Fhir.Validation.Tests
             // non-matching type: the type error is still reported
             validateActor(viaCases("Patient", ReferenceChecks.Exists | ReferenceChecks.TargetType))
                 .FailedWith("not one of the allowed target types");
+        }
+
+        [TestMethod]
+        public void SingleSchemaTargetProfileCheckControlsTargetValidation()
+        {
+            // by default the target is validated against the single schema
+            validateActor(via()).SucceededWith("Validation was triggered");
+
+            // without TargetProfile the reference is still resolved, but the schema must not run
+            var result = validateActor(via(checks: ReferenceChecks.Exists));
+            Assert.IsTrue(result.IsSuccessful);
+            Assert.IsFalse(result.Evidence.OfType<IssueAssertion>().Any(), "the target should not have been validated");
+
+            // an unresolvable reference is still reported
+            validateActor(via(checks: ReferenceChecks.Exists), reference: "#p2")
+                .SucceededWith("Cannot resolve reference");
+        }
+
+        [TestMethod]
+        public void SingleSchemaTargetTypeCheckIsInert()
+        {
+            // this form declares no target types, so TargetType has nothing to check: adding it
+            // must behave exactly like Exists on its own
+            var result = validateActor(via(checks: ReferenceChecks.Exists | ReferenceChecks.TargetType));
+
+            Assert.IsTrue(result.IsSuccessful);
+            Assert.IsFalse(result.Evidence.OfType<IssueAssertion>().Any(), "the target should not have been validated");
         }
     }
 }


### PR DESCRIPTION
Small follow-up to #683 and #685, and the last open-source piece the advisor framework redesign needs before the enterprise rework can start.

## The gap

`ReferenceChecks` was introduced in #683, but only the target-cases constructor accepts it:

```csharp
public ReferencedInstanceValidator(IAssertion schema,
    IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null)

public ReferencedInstanceValidator(IEnumerable<TargetCase> targetCases,
    IEnumerable<AggregationMode>? aggregationRules = null, ReferenceVersionRules? versioningRules = null,
    ReferenceChecks checks = ReferenceChecks.All)
```

The single-schema form is not legacy: `TypeReferenceBuilder` still falls back to it when a reference declares no target profiles. So there was no way to reduce the checks on such a validator. The private copy constructor added in #685 is not a substitute — it is private, and rewriting an existing validator's target schemas is not the same thing as configuring one.

## Why the parameter alone would have been inert

`validateTarget` short-circuited the single-schema form straight to the schema, resting on an invariant that this PR removes:

```csharp
// The legacy single-schema form does no type checking of its own, and can only be
// constructed with Checks == All, so the target is always validated against the schema.
if (TargetCases is null)
    return Schema!.ValidateOne(target, vc, state);
```

That branch now honours `TargetProfile`, which is the flag that carries meaning for this form. `TargetType` genuinely has nothing to check — the form declares no target types — so it is **documented as inert on the constructor rather than rejected**, letting a caller pass `All` or any subset without special-casing which form it is holding. `Exists` already worked for both forms, via `Checks.HasFlag(Exists)` upstream and `needsTarget`.

## Behavioural impact

None for anything constructible before this PR. The single-schema form could only have `Checks == All`, and the copy constructor preserves whatever the original carried. `ToJson` already emitted `checks` only when it differs from `All`, so no schema snapshots move.

## Tests

The `via()` helper gained a `checks` parameter, plus two tests: one that `TargetProfile` gates whether the target is validated (while an unresolvable reference is still reported), and one that `TargetType` on its own behaves exactly like `Exists` for this form.

Green: core 303 passed; R4 compilation 497 passed, 3 skipped (the usual `[Ignore]`d regeneration helpers).

## Motivation

Groundwork for the redesign of the Advisor Framework ([HL7 spec](https://confluence.hl7.org/spaces/FHIR/pages/281216179/Validator+Advisor+Framework)) in the enterprise validator, where a `reference` rule's `exists` / `type` / `valid` options map onto `ReferenceChecks`. Without this, those options could not be applied to references without target profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
